### PR TITLE
Add missing JSON syntax highlighting

### DIFF
--- a/src/components/atoms/CodeBlock.vue
+++ b/src/components/atoms/CodeBlock.vue
@@ -8,6 +8,7 @@ import 'prismjs/components/prism-c'
 import 'prismjs/components/prism-cpp'
 import 'prismjs/components/prism-fortran'
 import 'prismjs/components/prism-javascript'
+import 'prismjs/components/prism-json'
 import 'prismjs/components/prism-python'
 import 'prismjs/components/prism-markdown'
 import 'prismjs/components/prism-matlab'
@@ -32,6 +33,7 @@ const detectedLanguage = computed(() => {
     jsx: 'javascript',
     ts: 'javascript',
     tsx: 'javascript',
+    json: 'json',
     py: 'python',
     python: 'python',
     css: 'css',


### PR DESCRIPTION
Fixes #81 

The updates have been deployed to the demo, and the following page contains the fix - https://akhuoa.github.io/pmrapp-frontend/workspaces/add/file/317fdad54e9aa42c0bd3e06b61ea9d9833d9364c/human_body_metadata_context_info.json.
