### PR TITLE
Update button text for OpenCOR

### DIFF
--- a/src/components/organisms/ExposureDetail.test.ts
+++ b/src/components/organisms/ExposureDetail.test.ts
@@ -191,12 +191,12 @@ describe('ExposureDetail', () => {
     expect(viewItems).toHaveLength(3)
   })
 
-  it('renders "Open in OpenCOR\'s web app" link that opens in new tab', async () => {
+  it('renders "Open with OpenCOR\'s Web app" link that opens in new tab', async () => {
     const wrapper = await mountComponent()
 
     const openCorLink = wrapper
       .findAll('a')
-      .find((link) => link.text().trim() === "Open in OpenCOR's web app")
+      .find((link) => link.text().trim() === "Open with OpenCOR's Web app")
 
     expect(openCorLink?.exists()).toBe(true)
     expect(openCorLink?.attributes('target')).toBe('_blank')

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -609,7 +609,7 @@ onMounted(async () => {
                 rel="noopener noreferrer"
                 :content-section="`Exposure Detail - ${pageTitle}`"
               >
-                Open in OpenCOR's web app
+                Open with OpenCOR's Web app
               </ActionButton>
             </li>
             <li


### PR DESCRIPTION
Fixes #86

As described in #86, the button is now renamed to "**Open with OpenCOR's Web app**".

https://akhuoa.github.io/pmrapp-frontend/exposure/01f6a47881da1925315d1d89d3a8d901/zhang_holden_kodama_honjo_lei_varghese_boyett_2000.cellml?updated
