### PR TITLE
Remove the text from the download button

### DIFF
--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -472,15 +472,16 @@ onMounted(async () => {
         <div class="box p-0! overflow-hidden">
           <div class="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700">
             <span>{{ generatedCodeFilename }}</span>
-            <button
+            <ActionButton
               @click="downloadCode"
-              class="flex items-center cursor-pointer gap-2 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+              variant="icon"
+              content-section="Exposure Detail"
               title="Download"
               aria-label="Download"
             >
               <DownloadIcon class="w-4 h-4" />
               <span class="sr-only">Download</span>
-            </button>
+            </ActionButton>
           </div>
           <CodeBlock
             :code="generatedCode"
@@ -527,15 +528,16 @@ onMounted(async () => {
                 </RouterLink>
               </div>
               <div class="flex items-center gap-2 ml-4 flex-shrink-0">
-                <button
+                <ActionButton
                   @click="downloadFile(entry[0])"
-                  class="ml-4 p-2 text-gray-500 cursor-pointer hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
+                  variant="icon"
+                  content-section="Exposure Detail"
                   :title="`Download ${entry[0]}`"
                   :aria-label="`Download ${entry[0]}`"
                 >
                   <DownloadIcon class="w-4 h-4" />
                   <span class="sr-only">Download</span>
-                </button>
+                </ActionButton>
               </div>
             </div>
           </li>

--- a/src/components/organisms/WorkspaceDetail.vue
+++ b/src/components/organisms/WorkspaceDetail.vue
@@ -253,16 +253,17 @@ watch(() => [props.alias, props.commitId, props.path], loadWorkspaceInfo)
                 {{ entry.name }}
               </RouterLink>
             </div>
-            <button
+            <ActionButton
               v-if="entry.kind !== 'tree'"
+              variant="icon"
+              content-section="Workspace Detail"
               @click="downloadFile(entry.name)"
-              class="ml-4 p-2 text-gray-500 cursor-pointer hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
               :title="`Download ${entry.name}`"
               :aria-label="`Download ${entry.name}`"
             >
               <DownloadIcon class="w-4 h-4" />
               <span class="sr-only">Download</span>
-            </button>
+            </ActionButton>
           </div>
         </li>
       </ul>

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -156,15 +156,16 @@ onBeforeUnmount(() => {
             <CodeIcon class="w-4 h-4" v-else />
             {{ showCode ? 'Preview' : 'Code' }}
           </button>
-          <button
+          <ActionButton
+            variant="icon"
+            content-section="Workspace File Detail"
             @click="downloadFile"
-            class="flex items-center cursor-pointer gap-2 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded transition-colors"
             title="Download"
             :aria-label="'Download'"
           >
             <DownloadIcon class="w-4 h-4" />
             <span class="sr-only">Download</span>
-          </button>
+          </ActionButton>
         </div>
       </div>
 


### PR DESCRIPTION
Fixes #88.

The "Download" text on the download buttons has been removed (hidden from the UI, but I keep it for screen readers). On top of that, I also updated the button types to `<ActionButton />` for tracking. 

https://akhuoa.github.io/pmrapp-frontend/exposures/210f6601f6461be8443592ff071d2592/baylor_hollingworth_chandler_2002_a.cellml/cellml_codegen


However, for files that can't be displayed, I keep the download text on the button in the preview area as a special case, since it is a different button type, and it doesn't look nice if I remove the text.
https://akhuoa.github.io/pmrapp-frontend/workspaces/59c/file/5235f140f05975a62ccea67e4854ea79ca6ed984/iyer_mazhari_winslow_2004_new1.omex