### PR TITLE
Download filename update

### DIFF
--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -133,6 +133,7 @@ const navigationFiles = computed(() => {
 const handleDownloadWorkspaceArchive = async (format: 'zip' | 'tgz') => {
   if (!exposureInfo.value) return
 
+  const fileName = exposureInfo.value.exposure.description || ''
   const loadingRef = format === 'zip' ? isDownloadingWorkspaceZip : isDownloadingWorkspaceTgz
   loadingRef.value = true
 
@@ -142,6 +143,7 @@ const handleDownloadWorkspaceArchive = async (format: 'zip' | 'tgz') => {
       exposureInfo.value.workspace_alias,
       exposureInfo.value.exposure.commit_id,
       format,
+      fileName,
     )
   } catch (err) {
     console.error('Error downloading workspace archive:', err)

--- a/src/components/organisms/WorkspaceDetail.vue
+++ b/src/components/organisms/WorkspaceDetail.vue
@@ -112,6 +112,7 @@ const downloadFile = async (filename: string) => {
 const handleDownloadWorkspaceArchive = async (format: 'zip' | 'tgz') => {
   if (!workspaceInfo.value) return
 
+  const fileName = workspaceInfo.value.workspace.description || ''
   const loadingRef = format === 'zip' ? isDownloadingWorkspaceZip : isDownloadingWorkspaceTgz
   loadingRef.value = true
 
@@ -120,7 +121,8 @@ const handleDownloadWorkspaceArchive = async (format: 'zip' | 'tgz') => {
       workspaceInfo.value.workspace.url,
       props.alias,
       workspaceInfo.value.commit.commit_id,
-      format
+      format,
+      fileName,
     )
   } catch (err) {
     console.error('Error downloading workspace archive:', err)

--- a/src/services/downloadUrlService.ts
+++ b/src/services/downloadUrlService.ts
@@ -7,6 +7,7 @@ export const downloadWorkspaceArchive = async (
   alias: string,
   commitId: string,
   format: 'zip' | 'tgz',
+  fileName?: string,
 ): Promise<void> => {
   if (!alias || !commitId) {
     console.error('Alias and commit ID are required to download workspace archive.')
@@ -22,8 +23,8 @@ export const downloadWorkspaceArchive = async (
     }
 
     const blob = await response.blob()
-    const fileName = `${alias}.${format === 'tgz' ? 'tar.gz' : format}`
-    downloadFileFromBlob(blob, fileName)
+    const fileNameWithExtension = `${fileName || alias}.${format === 'tgz' ? 'tar.gz' : format}`
+    downloadFileFromBlob(blob, fileNameWithExtension)
   } catch (error) {
     console.error('Error downloading workspace archive:', error)
     throw error


### PR DESCRIPTION
Fixes #87.

This PR updates the workspace archive file name (both `.zip` and `.tar.gz`) to use `alias` as a fallback.
Since the archive service is implemented via the API, it cannot update the zipped folder's name on the client side.
I've added a comment at https://github.com/ABI-Software/pmrplatform-tracker/issues/33#issuecomment-3970398773 so that the new API will use the expected file/folder name.

The update is available on https://akhuoa.github.io/pmrapp-frontend/exposure/01f6a47881da1925315d1d89d3a8d901/zhang_holden_kodama_honjo_lei_varghese_boyett_2000.cellml.
