### PR TITLE
Add cursor pointer to backtotop

### DIFF
--- a/src/components/atoms/BackToTop.test.ts
+++ b/src/components/atoms/BackToTop.test.ts
@@ -3,17 +3,12 @@ import { afterEach, describe, expect, it } from 'vitest'
 import BackToTop from '@/components/atoms/BackToTop.vue'
 
 describe('BackToTop', () => {
-  const originalScrollY = Object.getOwnPropertyDescriptor(window, 'scrollY')
   let wrapper: VueWrapper<any> | null = null
 
   afterEach(() => {
     if (wrapper) {
       wrapper.unmount()
       wrapper = null
-    }
-
-    if (originalScrollY) {
-      Object.defineProperty(window, 'scrollY', originalScrollY)
     }
   })
 

--- a/src/components/atoms/BackToTop.test.ts
+++ b/src/components/atoms/BackToTop.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import BackToTop from '@/components/atoms/BackToTop.vue'
 
 describe('BackToTop', () => {
-  let wrapper: VueWrapper<any> | null = null
+  let wrapper: VueWrapper<InstanceType<typeof BackToTop>> | null = null
 
   afterEach(() => {
     if (wrapper) {

--- a/src/components/atoms/BackToTop.test.ts
+++ b/src/components/atoms/BackToTop.test.ts
@@ -1,23 +1,29 @@
-import { mount } from '@vue/test-utils'
+import { mount, type VueWrapper } from '@vue/test-utils'
 import { afterEach, describe, expect, it } from 'vitest'
 import BackToTop from '@/components/atoms/BackToTop.vue'
 
 describe('BackToTop', () => {
   const originalScrollY = Object.getOwnPropertyDescriptor(window, 'scrollY')
+  let wrapper: VueWrapper<any> | null = null
 
   afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount()
+      wrapper = null
+    }
+
     if (originalScrollY) {
       Object.defineProperty(window, 'scrollY', originalScrollY)
     }
   })
 
   it('does not render the button when not scrolled down', () => {
-    const wrapper = mount(BackToTop)
+    wrapper = mount(BackToTop)
     expect(wrapper.find('button').exists()).toBe(false)
   })
 
   it('button has cursor-pointer class when visible', async () => {
-    const wrapper = mount(BackToTop)
+    wrapper = mount(BackToTop)
     // Simulate scrolling down more than 300px
     Object.defineProperty(window, 'scrollY', { value: 400, writable: true, configurable: true })
     window.dispatchEvent(new Event('scroll'))

--- a/src/components/atoms/BackToTop.test.ts
+++ b/src/components/atoms/BackToTop.test.ts
@@ -1,0 +1,21 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import BackToTop from '@/components/atoms/BackToTop.vue'
+
+describe('BackToTop', () => {
+  it('does not render the button when not scrolled down', () => {
+    const wrapper = mount(BackToTop)
+    expect(wrapper.find('button').exists()).toBe(false)
+  })
+
+  it('button has cursor-pointer class when visible', async () => {
+    const wrapper = mount(BackToTop)
+    // Simulate scrolling down more than 300px
+    Object.defineProperty(window, 'scrollY', { value: 400, writable: true })
+    window.dispatchEvent(new Event('scroll'))
+    await wrapper.vm.$nextTick()
+    const button = wrapper.find('button')
+    expect(button.exists()).toBe(true)
+    expect(button.classes()).toContain('cursor-pointer')
+  })
+})

--- a/src/components/atoms/BackToTop.test.ts
+++ b/src/components/atoms/BackToTop.test.ts
@@ -1,8 +1,16 @@
 import { mount } from '@vue/test-utils'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import BackToTop from '@/components/atoms/BackToTop.vue'
 
 describe('BackToTop', () => {
+  const originalScrollY = Object.getOwnPropertyDescriptor(window, 'scrollY')
+
+  afterEach(() => {
+    if (originalScrollY) {
+      Object.defineProperty(window, 'scrollY', originalScrollY)
+    }
+  })
+
   it('does not render the button when not scrolled down', () => {
     const wrapper = mount(BackToTop)
     expect(wrapper.find('button').exists()).toBe(false)
@@ -11,7 +19,7 @@ describe('BackToTop', () => {
   it('button has cursor-pointer class when visible', async () => {
     const wrapper = mount(BackToTop)
     // Simulate scrolling down more than 300px
-    Object.defineProperty(window, 'scrollY', { value: 400, writable: true })
+    Object.defineProperty(window, 'scrollY', { value: 400, writable: true, configurable: true })
     window.dispatchEvent(new Event('scroll'))
     await wrapper.vm.$nextTick()
     const button = wrapper.find('button')

--- a/src/components/atoms/BackToTop.test.ts
+++ b/src/components/atoms/BackToTop.test.ts
@@ -24,6 +24,24 @@ describe('BackToTop', () => {
     expect(wrapper.find('button').exists()).toBe(false)
   })
 
+  it('renders button immediately when mounted with scrollY > 300', async () => {
+    // Capture original descriptor before modifying.
+    originalScrollYDescriptor = Object.getOwnPropertyDescriptor(window, 'scrollY')
+      || Object.getOwnPropertyDescriptor(Object.getPrototypeOf(window), 'scrollY')
+
+    // Set scrollY before mounting to simulate deep link or scroll restoration.
+    Object.defineProperty(window, 'scrollY', { value: 400, writable: true, configurable: true })
+    window.dispatchEvent(new Event('scroll'))
+
+    wrapper = mount(BackToTop)
+    await wrapper.vm.$nextTick()
+
+    // Button should be visible immediately without needing a scroll event.
+    const button = wrapper.find('button')
+    expect(button.exists()).toBe(true)
+    expect(button.classes()).toContain('cursor-pointer')
+  })
+
   it('button has cursor-pointer class when visible', async () => {
     wrapper = mount(BackToTop)
 

--- a/src/components/atoms/BackToTop.test.ts
+++ b/src/components/atoms/BackToTop.test.ts
@@ -4,11 +4,18 @@ import BackToTop from '@/components/atoms/BackToTop.vue'
 
 describe('BackToTop', () => {
   let wrapper: VueWrapper<InstanceType<typeof BackToTop>> | null = null
+  let originalScrollYDescriptor: PropertyDescriptor | undefined
 
   afterEach(() => {
     if (wrapper) {
       wrapper.unmount()
       wrapper = null
+    }
+
+    // Restore original scrollY descriptor if it was captured.
+    if (originalScrollYDescriptor !== undefined) {
+      Object.defineProperty(window, 'scrollY', originalScrollYDescriptor)
+      originalScrollYDescriptor = undefined
     }
   })
 
@@ -19,7 +26,12 @@ describe('BackToTop', () => {
 
   it('button has cursor-pointer class when visible', async () => {
     wrapper = mount(BackToTop)
-    // Simulate scrolling down more than 300px
+
+    // Capture original descriptor before modifying.
+    originalScrollYDescriptor = Object.getOwnPropertyDescriptor(window, 'scrollY')
+      || Object.getOwnPropertyDescriptor(Object.getPrototypeOf(window), 'scrollY')
+
+    // Simulate scrolling down more than 300px.
     Object.defineProperty(window, 'scrollY', { value: 400, writable: true, configurable: true })
     window.dispatchEvent(new Event('scroll'))
     await wrapper.vm.$nextTick()

--- a/src/components/atoms/BackToTop.vue
+++ b/src/components/atoms/BackToTop.vue
@@ -18,6 +18,7 @@ const scrollToTop = () => {
 }
 
 onMounted(() => {
+  checkScroll() // Check initial scroll position.
   window.addEventListener('scroll', checkScroll)
 })
 

--- a/src/components/atoms/BackToTop.vue
+++ b/src/components/atoms/BackToTop.vue
@@ -32,6 +32,7 @@ onUnmounted(() => {
       v-if="isVisible"
       @click="scrollToTop"
       class="fixed bottom-8 right-8 button-rounded-full z-40 cursor-pointer"
+      type="button"
       aria-label="Back to top"
     >
       <ArrowUpIcon />

--- a/src/components/atoms/BackToTop.vue
+++ b/src/components/atoms/BackToTop.vue
@@ -31,7 +31,7 @@ onUnmounted(() => {
     <button
       v-if="isVisible"
       @click="scrollToTop"
-      class="fixed bottom-8 right-8 button-rounded-full z-40"
+      class="fixed bottom-8 right-8 button-rounded-full z-40 cursor-pointer"
       aria-label="Back to top"
     >
       <ArrowUpIcon />


### PR DESCRIPTION
Fixes #79.

### Changes
- Add `cursor: pointer` to the back-to-top button.
- Add `type: button` to the back-to-top button for accessibility.
- Add a scroll top check on mounted to show the back-to-top button on page load with initial scroll.
- Add unit test for the back-to-top component.

The updates are available for testing on https://akhuoa.github.io/pmrapp-frontend/exposures. 
The only visual change is the cursor pointer on mouse over the back-to-top button.
