### PR TITLE
Sorting cache

### DIFF
--- a/src/components/molecules/List.test.ts
+++ b/src/components/molecules/List.test.ts
@@ -1,0 +1,141 @@
+import { flushPromises, mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { nextTick, ref } from 'vue'
+import List from '@/components/molecules/List.vue'
+
+const mockRouterReplace = vi.fn()
+const mockRouteQuery = ref<Record<string, string>>({})
+
+// Mock Vue Router.
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: mockRouteQuery.value }),
+  useRouter: () => ({
+    replace: mockRouterReplace,
+  }),
+}))
+
+type TestItem = {
+  alias: string
+  entity: {
+    id: number
+    created_ts: number
+    description: string | null
+  }
+}
+
+const testItems: TestItem[] = [
+  { alias: 'item-1', entity: { id: 1, created_ts: 1000, description: 'Alpha' } },
+  { alias: 'item-2', entity: { id: 2, created_ts: 2000, description: 'Beta' } },
+  { alias: 'item-3', entity: { id: 3, created_ts: 3000, description: 'Gamma' } },
+]
+
+const mountList = (queryOverrides: Record<string, string> = {}) => {
+  mockRouteQuery.value = queryOverrides
+
+  return mount(List, {
+    props: {
+      items: testItems,
+      isLoading: false,
+      error: null,
+      errorTitle: 'Error',
+      contentSection: 'Test Listing',
+      emptyMessage: 'No items.',
+      routeBase: '/test',
+      getTitle: (item: TestItem) => item.entity.description || item.alias,
+    },
+    global: {
+      stubs: {
+        RouterLink: { template: '<a><slot /></a>' },
+        ListToolbar: {
+          name: 'ListToolbar',
+          template: '<div />',
+          props: ['filterQuery', 'sortBy', 'isLoading', 'contentSection'],
+          emits: ['update:filterQuery', 'update:sortBy', 'refresh'],
+        },
+        ListContent: {
+          template: '<div><slot name="item" /></div>',
+          props: ['items', 'error', 'isLoading', 'errorTitle', 'emptyMessage'],
+        },
+        ListItem: {
+          template: '<div>{{ title }}</div>',
+          props: ['title', 'link'],
+        },
+      },
+    },
+  })
+}
+
+describe('List.vue – sort URL persistence', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockRouteQuery.value = {}
+  })
+
+  it('initialises sortBy to DEFAULT_SORT_OPTION when no sort query param is present', async () => {
+    const wrapper = mountList()
+    await flushPromises()
+    await nextTick()
+
+    const toolbar = wrapper.findComponent({ name: 'ListToolbar' })
+    expect(toolbar.props('sortBy')).toBe('description-asc')
+  })
+
+  it('initialises sortBy from a valid sort query param in the URL', async () => {
+    const wrapper = mountList({ sort: 'id-desc' })
+    await flushPromises()
+    await nextTick()
+
+    const toolbar = wrapper.findComponent({ name: 'ListToolbar' })
+    expect(toolbar.props('sortBy')).toBe('id-desc')
+  })
+
+  it('ignores an invalid sort query param and falls back to DEFAULT_SORT_OPTION', async () => {
+    const wrapper = mountList({ sort: 'invalid-value' })
+    await flushPromises()
+    await nextTick()
+
+    const toolbar = wrapper.findComponent({ name: 'ListToolbar' })
+    expect(toolbar.props('sortBy')).toBe('description-asc')
+  })
+
+  it('initialises filterQuery from filter query param and sortBy from sort query param', async () => {
+    const wrapper = mountList({ filter: 'alpha', sort: 'date-asc' })
+    await flushPromises()
+    await nextTick()
+
+    const toolbar = wrapper.findComponent({ name: 'ListToolbar' })
+    expect(toolbar.props('filterQuery')).toBe('alpha')
+    expect(toolbar.props('sortBy')).toBe('date-asc')
+  })
+
+  it('updates the URL when sortBy changes, preserving existing filter', async () => {
+    const wrapper = mountList({ filter: 'beta' })
+    await flushPromises()
+    await nextTick()
+
+    mockRouterReplace.mockClear()
+
+    // Simulate user changing the sort option via the toolbar emit.
+    await wrapper.findComponent({ name: 'ListToolbar' }).vm.$emit('update:sortBy', 'id-asc')
+    await nextTick()
+
+    const lastCall = mockRouterReplace.mock.calls.at(-1)?.[0]
+    expect(lastCall?.query?.filter).toBe('beta')
+    expect(lastCall?.query?.sort).toBe('id-asc')
+  })
+
+  it('removes the sort query param when sortBy is reset to the default', async () => {
+    const wrapper = mountList({ sort: 'id-desc' })
+    await flushPromises()
+    await nextTick()
+
+    mockRouterReplace.mockClear()
+
+    // Simulate user resetting sort back to description-asc (the default).
+    await wrapper.findComponent({ name: 'ListToolbar' }).vm.$emit('update:sortBy', 'description-asc')
+    await nextTick()
+
+    const lastCall = mockRouterReplace.mock.calls.at(-1)?.[0]
+    expect(lastCall?.query?.sort).toBeUndefined()
+  })
+})

--- a/src/components/molecules/List.vue
+++ b/src/components/molecules/List.vue
@@ -39,7 +39,8 @@ const sortBy = ref<SortOption>(initialSort)
 // Sync filter and sort with URL query parameters.
 watch([filterQuery, sortBy], ([newFilter, newSort]) => {
   const query: Record<string, string> = {}
-  if (newFilter.trim()) query.filter = newFilter
+  const trimmedFilter = newFilter.trim()
+  if (trimmedFilter) query.filter = trimmedFilter
   if (newSort !== DEFAULT_SORT_OPTION) query.sort = newSort
   router.replace({ query })
 })

--- a/src/components/molecules/List.vue
+++ b/src/components/molecules/List.vue
@@ -6,7 +6,7 @@ import ListItem from '@/components/molecules/ListItem.vue'
 import ListToolbar from '@/components/molecules/ListToolbar.vue'
 import type { SortOption } from '@/types/common'
 import { formatDate } from '@/utils/format'
-import { DEFAULT_SORT_OPTION, sortEntities } from '@/utils/sort'
+import { DEFAULT_SORT_OPTION, isValidSortOption, sortEntities } from '@/utils/sort'
 
 interface Props<T> {
   items: T[]
@@ -29,11 +29,17 @@ const emit = defineEmits<{
 const route = useRoute()
 const router = useRouter()
 const filterQuery = ref((route.query.filter as string) || '')
-const sortBy = ref<SortOption>(DEFAULT_SORT_OPTION)
+const sortBy = ref<SortOption>(
+  isValidSortOption(route.query.sort as string)
+    ? (route.query.sort as SortOption)
+    : DEFAULT_SORT_OPTION,
+)
 
-// Sync filter query with URL query parameter.
-watch(filterQuery, (newValue) => {
-  const query = newValue.trim() ? { filter: newValue } : {}
+// Sync filter and sort with URL query parameters.
+watch([filterQuery, sortBy], ([newFilter, newSort]) => {
+  const query: Record<string, string> = {}
+  if (newFilter.trim()) query.filter = newFilter
+  if (newSort !== DEFAULT_SORT_OPTION) query.sort = newSort
   router.replace({ query })
 })
 

--- a/src/components/molecules/List.vue
+++ b/src/components/molecules/List.vue
@@ -29,11 +29,12 @@ const emit = defineEmits<{
 const route = useRoute()
 const router = useRouter()
 const filterQuery = ref((route.query.filter as string) || '')
-const sortBy = ref<SortOption>(
-  isValidSortOption(route.query.sort)
-    ? route.query.sort
-    : DEFAULT_SORT_OPTION,
-)
+const sortQuery = route.query.sort
+const initialSort: SortOption =
+  typeof sortQuery === 'string' && isValidSortOption(sortQuery)
+    ? sortQuery
+    : DEFAULT_SORT_OPTION
+const sortBy = ref<SortOption>(initialSort)
 
 // Sync filter and sort with URL query parameters.
 watch([filterQuery, sortBy], ([newFilter, newSort]) => {

--- a/src/components/molecules/List.vue
+++ b/src/components/molecules/List.vue
@@ -30,8 +30,8 @@ const route = useRoute()
 const router = useRouter()
 const filterQuery = ref((route.query.filter as string) || '')
 const sortBy = ref<SortOption>(
-  isValidSortOption(route.query.sort as string)
-    ? (route.query.sort as SortOption)
+  isValidSortOption(route.query.sort)
+    ? route.query.sort
     : DEFAULT_SORT_OPTION,
 )
 

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -29,9 +29,13 @@ export const SORT_OPTIONS_GROUPED: SortOptionGroup[] = [
 export const DEFAULT_SORT_OPTION: SortOption = 'description-asc'
 
 /**
- * Returns true if the given string is a valid SortOption.
+ * Returns true if the given runtime value is a valid SortOption.
  */
-export const isValidSortOption = (value: string): value is SortOption => {
+export const isValidSortOption = (value: unknown): value is SortOption => {
+  if (typeof value !== 'string') {
+    return false
+  }
+
   const fields =
     SORT_OPTIONS_GROUPED.find((g) => g.group === 'Fields')?.options.map((o) => o.value) ?? []
   const directions =

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -29,6 +29,17 @@ export const SORT_OPTIONS_GROUPED: SortOptionGroup[] = [
 export const DEFAULT_SORT_OPTION: SortOption = 'description-asc'
 
 /**
+ * Returns true if the given string is a valid SortOption.
+ */
+export const isValidSortOption = (value: string): value is SortOption => {
+  const fields =
+    SORT_OPTIONS_GROUPED.find((g) => g.group === 'Fields')?.options.map((o) => o.value) ?? []
+  const directions =
+    SORT_OPTIONS_GROUPED.find((g) => g.group === 'Direction')?.options.map((o) => o.value) ?? []
+  return fields.some((f) => directions.some((d) => `${f}-${d}` === value))
+}
+
+/**
  * Generic sorting function for entities with id, description, and created_ts.
  */
 export function sortEntities<T extends SortableEntity>(items: T[], sortBy: SortOption): T[] {

--- a/tsconfig.vitest.json
+++ b/tsconfig.vitest.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.vitest.tsbuildinfo",
     "types": ["node", "jsdom"]
   },


### PR DESCRIPTION
Fixes #64.

### Changes
The sorting on listing pages ([workspaces](https://akhuoa.github.io/pmrapp-frontend/workspaces) & [exposures](https://akhuoa.github.io/pmrapp-frontend/exposures)) is cached (via [URL query](https://akhuoa.github.io/pmrapp-frontend/exposures?sort=id-asc)) so that when the user goes back to the listing from a detail page, they can see the previous sorting.

The demo page is updated with the changes.
https://akhuoa.github.io/pmrapp-frontend/exposures?sort=id-asc