### PR TITLE
Fix mouse drag from input to backdrop

### DIFF
--- a/src/components/organisms/SearchOverlay.vue
+++ b/src/components/organisms/SearchOverlay.vue
@@ -16,12 +16,13 @@ const searchInputRef = ref<InstanceType<typeof SearchInput> | null>(null)
 
 let isMouseDownOnBackdrop = false
 
-const handleBackdropMouseDown = () => {
+const handleBackdropMouseDown = (event: MouseEvent) => {
+  if (event.button !== 0) return
   isMouseDownOnBackdrop = true
 }
 
-const handleBackdropClick = () => {
-  if (isMouseDownOnBackdrop) {
+const handleBackdropMouseUp = (event: MouseEvent) => {
+  if (isMouseDownOnBackdrop && event.target === event.currentTarget) {
     emit('close')
   }
   isMouseDownOnBackdrop = false
@@ -43,6 +44,7 @@ watch(
       document.addEventListener('keydown', handleKeyDown)
     } else {
       document.removeEventListener('keydown', handleKeyDown)
+      isMouseDownOnBackdrop = false
     }
   },
 )
@@ -82,7 +84,7 @@ const getInitialKind = (): string => {
     v-if="show"
     class="fixed inset-0 bg-gray-800/75 dark:bg-gray-900/75 z-50 flex justify-center items-start pt-20"
     @mousedown.self="handleBackdropMouseDown"
-    @click.self="handleBackdropClick"
+    @mouseup="handleBackdropMouseUp"
   >
     <div class="w-full max-w-4xl bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4">
       <div class="flex justify-between items-center mb-4 border-b border-gray-200 dark:border-gray-700 pb-2">

--- a/src/components/organisms/SearchOverlay.vue
+++ b/src/components/organisms/SearchOverlay.vue
@@ -14,6 +14,19 @@ const router = useRouter()
 const route = useRoute()
 const searchInputRef = ref<InstanceType<typeof SearchInput> | null>(null)
 
+let isMouseDownOnBackdrop = false
+
+const handleBackdropMouseDown = () => {
+  isMouseDownOnBackdrop = true
+}
+
+const handleBackdropClick = () => {
+  if (isMouseDownOnBackdrop) {
+    emit('close')
+  }
+  isMouseDownOnBackdrop = false
+}
+
 const handleKeyDown = (event: KeyboardEvent) => {
   if (event.key === 'Escape') {
     emit('close')
@@ -68,7 +81,8 @@ const getInitialKind = (): string => {
   <div
     v-if="show"
     class="fixed inset-0 bg-gray-800/75 dark:bg-gray-900/75 z-50 flex justify-center items-start pt-20"
-    @click.self="emit('close')"
+    @mousedown.self="handleBackdropMouseDown"
+    @click.self="handleBackdropClick"
   >
     <div class="w-full max-w-4xl bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4">
       <div class="flex justify-between items-center mb-4 border-b border-gray-200 dark:border-gray-700 pb-2">


### PR DESCRIPTION
Fixes #119.

This issue occurs on Chrome and Safari.

### To reproduce the problem:

1. Visit https://physiome.github.io/pmrapp-frontend/.
2. Click the search icon in the navigation bar.
3. Type something like “noble”.
4. Select the input text using the mouse and drag it until the cursor reaches the outer overlay area, then release the mouse.
5. The search overlay should disappear.

### To verify the issue:

Perform the same steps on https://akhuoa.github.io/pmrapp-frontend/. 
The search overlay should remain the same.