### PR TITLE
Add sorting to search results

### DIFF
--- a/src/components/molecules/KeywordBrowser.vue
+++ b/src/components/molecules/KeywordBrowser.vue
@@ -4,7 +4,7 @@ import { useRouter } from 'vue-router'
 import SearchField from '@/components/atoms/SearchField.vue'
 import TermButton from '@/components/atoms/TermButton.vue'
 import { useSearchStore } from '@/stores/search'
-import { isValidTerm } from '@/utils/search'
+import { buildSearchQuery, isValidTerm } from '@/utils/search'
 
 interface Props {
   inSidebar: boolean
@@ -28,12 +28,13 @@ onMounted(async () => {
 
 const handleTermClick = async (kind: string, term: string) => {
   const currentRoute = router.currentRoute.value
+  const query = buildSearchQuery(kind, term, currentRoute.query)
   // If already on search page, replace query params to avoid duplicate navigation.
   // Otherwise, push to search page.
   if (currentRoute.path === '/search') {
-    await router.replace({ path: '/search', query: { kind, term } })
+    await router.replace({ path: '/search', query })
   } else {
-    await router.push({ path: '/search', query: { kind, term } })
+    await router.push({ path: '/search', query })
   }
 }
 

--- a/src/components/molecules/ListToolbar.vue
+++ b/src/components/molecules/ListToolbar.vue
@@ -56,7 +56,7 @@ const handleRefresh = () => {
       @click="handleRefresh"
     >
       <RefreshIcon />
-      <span>{{ isLoading ? 'Refreshing...' : 'Refresh' }}</span>
+      <span>{{ isLoading ? 'Loading...' : 'Refresh' }}</span>
     </ActionButton>
   </div>
 </template>

--- a/src/components/molecules/SearchResults.vue
+++ b/src/components/molecules/SearchResults.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import TermButton from '@/components/atoms/TermButton.vue'
 import FileIcon from '@/components/icons/FileIcon.vue'
 import ListContent from '@/components/molecules/ListContent.vue'
@@ -9,7 +9,7 @@ import { SEARCH_KIND_LABEL_MAP } from '@/constants/search'
 import type { SearchResult } from '@/types/search'
 import { getExposureIdFromResourcePath } from '@/utils/exposure'
 import { formatDate, formatNumber } from '@/utils/format'
-import { isValidTerm } from '@/utils/search'
+import { buildSearchQuery, isValidTerm } from '@/utils/search'
 
 interface Props {
   results: SearchResult[]
@@ -22,15 +22,16 @@ interface Props {
 const props = defineProps<Props>()
 
 const router = useRouter()
+const route = useRoute()
 
 const textHighlightClass = 'text-highlight font-semibold'
 
 const handleKeywordClick = (kind: string, keyword: string) => {
-  router.push({ path: '/search', query: { kind, term: keyword } })
+  router.push({ path: '/search', query: buildSearchQuery(kind, keyword, route.query) })
 }
 
 const handleAuthorClick = (kind: string, author: string) => {
-  router.push({ path: '/search', query: { kind, term: author } })
+  router.push({ path: '/search', query: buildSearchQuery(kind, author, route.query) })
 }
 
 const kindLabel = computed(() => {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -25,7 +25,7 @@ import { downloadFileFromContent, downloadWorkspaceFile } from '@/utils/download
 import { getExposureIdFromResourcePath } from '@/utils/exposure'
 import { formatFileCount } from '@/utils/format'
 import { formatLicenseUrl } from '@/utils/license'
-import { isValidTerm } from '@/utils/search'
+import { buildSearchQuery, isValidTerm } from '@/utils/search'
 import TermButton from '../atoms/TermButton.vue'
 
 const props = defineProps<{
@@ -306,7 +306,8 @@ const loadCodegenView = async () => {
 }
 
 const handleKeywordClick = (kind: string, keyword: string) => {
-  router.push({ path: '/search', query: { kind, term: keyword } })
+  const currentQuery = router.currentRoute.value.query
+  router.push({ path: '/search', query: buildSearchQuery(kind, keyword, currentQuery) })
 }
 
 const handleCitationAuthorClick = (authorParts: string[]) => {

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -69,7 +69,7 @@ watch([kind, term], async () => {
   await loadResults()
 })
 
-const loadResults = async () => {
+const loadResults = async (forceRefresh = false) => {
   if (!kind.value || !term.value) {
     // If no search parameters are provided, do not redirect.
     // Simply return without loading results to avoid confusing UX.
@@ -81,7 +81,7 @@ const loadResults = async () => {
   searchResults.value = []
 
   try {
-    searchResults.value = await searchStore.searchIndexTerm(kind.value, term.value)
+    searchResults.value = await searchStore.searchIndexTerm(kind.value, term.value, forceRefresh)
   } catch (err) {
     resultsError.value = err instanceof Error ? err.message : 'Failed to load search results'
     console.error('Failed to load search results:', err)
@@ -100,8 +100,8 @@ const sortedResults = computed(() => sortSearchResults(searchResults.value, sort
 
 const hasResults = computed(() => searchResults.value.length > 0)
 
-const handleRefresh = () => {
-  // emit('refresh')
+const handleRefresh = async () => {
+  await loadResults(true)
 }
 </script>
 

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -4,9 +4,12 @@ import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import SearchInput from '@/components/molecules/SearchInput.vue'
 import SearchResults from '@/components/molecules/SearchResults.vue'
+import SortDropdown from '@/components/molecules/SortDropdown.vue'
 import { useGlobalStateStore } from '@/stores/globalState'
 import { useSearchStore } from '@/stores/search'
+import type { SortOption } from '@/types/common'
 import type { SearchResult } from '@/types/search'
+import { DEFAULT_SORT_OPTION, SORT_OPTIONS_GROUPED, isValidSortOption, sortSearchResults } from '@/utils/sort'
 
 const route = useRoute()
 const router = useRouter()
@@ -20,6 +23,11 @@ const isLoading = ref(false)
 const resultsError = ref<string | null>(null)
 const searchInputRef = ref<InstanceType<typeof SearchInput> | null>(null)
 
+const sortQuery = route.query.sort
+const initialSort: SortOption =
+  typeof sortQuery === 'string' && isValidSortOption(sortQuery) ? sortQuery : DEFAULT_SORT_OPTION
+const sortBy = ref<SortOption>(initialSort)
+
 watch(
   () => globalState.isSearchFocusRequested,
   (isRequested) => {
@@ -29,6 +37,26 @@ watch(
     }
   },
 )
+
+watch(
+  () => route.query.sort,
+  (newSort) => {
+    const nextSort =
+      typeof newSort === 'string' && isValidSortOption(newSort) ? newSort : DEFAULT_SORT_OPTION
+    if (sortBy.value !== nextSort) {
+      sortBy.value = nextSort
+    }
+  },
+)
+
+// Sync sort with URL query parameters whilst preserving the kind and term params.
+watch(sortBy, (newSort) => {
+  const query: Record<string, string> = {}
+  if (kind.value) query.kind = kind.value
+  if (term.value) query.term = term.value
+  if (newSort !== DEFAULT_SORT_OPTION) query.sort = newSort
+  router.replace({ query })
+})
 
 onMounted(async () => {
   await loadResults()
@@ -63,14 +91,25 @@ const loadResults = async () => {
 const handleSearch = (searchKind: string, searchTerm: string) => {
   router.push({ path: '/search', query: { kind: searchKind, term: searchTerm } })
 }
+
+const sortedResults = computed(() => sortSearchResults(searchResults.value, sortBy.value))
+
+const hasResults = computed(() => searchResults.value.length > 0)
 </script>
 
 <template>
   <SearchInput ref="searchInputRef" :initial-kind="kind" :initial-term="term" @search="handleSearch" />
   <div class="mt-8">
     <main class="flex-1 min-w-0 relative">
+      <div v-if="hasResults || isLoading" class="mb-4 flex justify-end">
+        <SortDropdown
+          :model-value="sortBy"
+          :options="SORT_OPTIONS_GROUPED"
+          @update:model-value="(value) => (sortBy = value)"
+        />
+      </div>
       <SearchResults
-        :results="searchResults"
+        :results="sortedResults"
         :is-loading="isLoading"
         :error="resultsError"
         :term="term"

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -100,8 +100,9 @@ const hasResults = computed(() => searchResults.value.length > 0)
 </script>
 
 <template>
-  <div class="flex items-center justify-between">
+  <div class="flex items-center justify-between gap-4">
     <SearchInput
+      class="flex-1"
       ref="searchInputRef"
       :initial-kind="kind"
       :initial-term="term"

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -2,6 +2,8 @@
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import ActionButton from '@/components/atoms/ActionButton.vue'
+import RefreshIcon from '@/components/icons/RefreshIcon.vue'
 import SearchInput from '@/components/molecules/SearchInput.vue'
 import SearchResults from '@/components/molecules/SearchResults.vue'
 import SortDropdown from '@/components/molecules/SortDropdown.vue'
@@ -11,12 +13,10 @@ import type { SortOption } from '@/types/common'
 import type { SearchResult } from '@/types/search'
 import {
   DEFAULT_SORT_OPTION,
-  SORT_OPTIONS_GROUPED,
   isValidSortOption,
+  SORT_OPTIONS_GROUPED,
   sortSearchResults,
 } from '@/utils/sort'
-import ActionButton from '@/components/atoms/ActionButton.vue'
-import RefreshIcon from '@/components/icons/RefreshIcon.vue'
 
 const route = useRoute()
 const router = useRouter()

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -126,6 +126,7 @@ const handleRefresh = async () => {
       @update:model-value="(value) => (sortBy = value)"
     />
     <ActionButton
+      v-if="hasResults || isLoading"
       variant="secondary"
       size="lg"
       :disabled="isLoading"

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -10,6 +10,8 @@ import { useSearchStore } from '@/stores/search'
 import type { SortOption } from '@/types/common'
 import type { SearchResult } from '@/types/search'
 import { DEFAULT_SORT_OPTION, SORT_OPTIONS_GROUPED, isValidSortOption, sortSearchResults } from '@/utils/sort'
+import ActionButton from '@/components/atoms/ActionButton.vue'
+import RefreshIcon from '@/components/icons/RefreshIcon.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -97,12 +99,16 @@ const handleSearch = (searchKind: string, searchTerm: string) => {
 const sortedResults = computed(() => sortSearchResults(searchResults.value, sortBy.value))
 
 const hasResults = computed(() => searchResults.value.length > 0)
+
+const handleRefresh = () => {
+  // emit('refresh')
+}
 </script>
 
 <template>
-  <div class="flex items-center justify-between gap-4">
+  <div class="flex flex-col sm:flex-row gap-4 items-start sm:items-center justify-between">
     <SearchInput
-      class="flex-1"
+      class="flex-1 w-full sm:w-auto"
       ref="searchInputRef"
       :initial-kind="kind"
       :initial-term="term"
@@ -114,6 +120,16 @@ const hasResults = computed(() => searchResults.value.length > 0)
       :options="SORT_OPTIONS_GROUPED"
       @update:model-value="(value) => (sortBy = value)"
     />
+    <ActionButton
+      variant="secondary"
+      size="lg"
+      :disabled="isLoading"
+      content-section="Search Results"
+      @click="handleRefresh"
+    >
+      <RefreshIcon />
+      <span>{{ isLoading ? 'Loading...' : 'Refresh' }}</span>
+    </ActionButton>
   </div>
   <div class="mt-8">
     <main class="flex-1 min-w-0 relative">

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -100,16 +100,22 @@ const hasResults = computed(() => searchResults.value.length > 0)
 </script>
 
 <template>
-  <SearchInput ref="searchInputRef" :initial-kind="kind" :initial-term="term" @search="handleSearch" />
+  <div class="flex items-center justify-between">
+    <SearchInput
+      ref="searchInputRef"
+      :initial-kind="kind"
+      :initial-term="term"
+      @search="handleSearch"
+    />
+    <SortDropdown
+      v-if="hasResults || isLoading"
+      :model-value="sortBy"
+      :options="SORT_OPTIONS_GROUPED"
+      @update:model-value="(value) => (sortBy = value)"
+    />
+  </div>
   <div class="mt-8">
     <main class="flex-1 min-w-0 relative">
-      <div v-if="hasResults || isLoading" class="mb-4 flex justify-end">
-        <SortDropdown
-          :model-value="sortBy"
-          :options="SORT_OPTIONS_GROUPED"
-          @update:model-value="(value) => (sortBy = value)"
-        />
-      </div>
       <SearchResults
         :results="sortedResults"
         :is-loading="isLoading"

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -9,7 +9,12 @@ import { useGlobalStateStore } from '@/stores/globalState'
 import { useSearchStore } from '@/stores/search'
 import type { SortOption } from '@/types/common'
 import type { SearchResult } from '@/types/search'
-import { DEFAULT_SORT_OPTION, SORT_OPTIONS_GROUPED, isValidSortOption, sortSearchResults } from '@/utils/sort'
+import {
+  DEFAULT_SORT_OPTION,
+  SORT_OPTIONS_GROUPED,
+  isValidSortOption,
+  sortSearchResults,
+} from '@/utils/sort'
 import ActionButton from '@/components/atoms/ActionButton.vue'
 import RefreshIcon from '@/components/icons/RefreshIcon.vue'
 

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -89,7 +89,9 @@ const loadResults = async () => {
 }
 
 const handleSearch = (searchKind: string, searchTerm: string) => {
-  router.push({ path: '/search', query: { kind: searchKind, term: searchTerm } })
+  const query: Record<string, string> = { kind: searchKind, term: searchTerm }
+  if (sortBy.value !== DEFAULT_SORT_OPTION) query.sort = sortBy.value
+  router.push({ path: '/search', query })
 }
 
 const sortedResults = computed(() => sortSearchResults(searchResults.value, sortBy.value))

--- a/src/components/organisms/SearchOverlay.vue
+++ b/src/components/organisms/SearchOverlay.vue
@@ -3,6 +3,7 @@ import { nextTick, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import CloseButton from '@/components/atoms/CloseButton.vue'
 import SearchInput from '@/components/molecules/SearchInput.vue'
+import { buildSearchQuery } from '@/utils/search'
 
 const props = defineProps<{
   show: boolean
@@ -39,7 +40,7 @@ onUnmounted(() => {
 })
 
 const handleSearch = (searchKind: string, searchTerm: string) => {
-  router.push({ path: '/search', query: { kind: searchKind, term: searchTerm } })
+  router.push({ path: '/search', query: buildSearchQuery(searchKind, searchTerm, route.query) })
   emit('close')
 }
 

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -99,12 +99,16 @@ export const useSearchStore = defineStore('search', () => {
     }
   }
 
-  const searchIndexTerm = async (kind: string, term: string): Promise<SearchResult[]> => {
+  const searchIndexTerm = async (
+    kind: string,
+    term: string,
+    forceRefresh = false,
+  ): Promise<SearchResult[]> => {
     const cacheKey = `${kind}:${term}`
     const cached = searchResultsCache.value.get(cacheKey)
 
     // Return cached results if valid.
-    if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
+    if (!forceRefresh && cached && Date.now() - cached.timestamp < CACHE_TTL) {
       return cached.results
     }
 

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,7 +1,7 @@
+import type { LocationQuery, LocationQueryRaw } from 'vue-router'
 import type { SortableEntity } from '@/types/common'
 import type { QueryFilterOptions, TextSegment } from '@/types/search'
 import { DEFAULT_SORT_OPTION, isValidSortOption } from '@/utils/sort'
-import type { LocationQuery, LocationQueryRaw } from 'vue-router'
 
 /**
  * Returns true if a search term is valid (non-empty and not a broken URN).

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,5 +1,7 @@
 import type { SortableEntity } from '@/types/common'
 import type { QueryFilterOptions, TextSegment } from '@/types/search'
+import { DEFAULT_SORT_OPTION, isValidSortOption } from '@/utils/sort'
+import type { LocationQuery, LocationQueryRaw } from 'vue-router'
 
 /**
  * Returns true if a search term is valid (non-empty and not a broken URN).
@@ -26,6 +28,28 @@ export const normaliseSearchText = (text: string): string => {
     .replace(/[^a-zA-Z0-9\s]/g, ' ')
     .replace(/\s+/g, ' ')
     .trim()
+}
+
+/**
+ * Builds a /search query and preserves the current sort option when it is valid.
+ */
+export const buildSearchQuery = (
+  kind: string,
+  term: string,
+  currentQuery: LocationQuery,
+): LocationQueryRaw => {
+  const query: LocationQueryRaw = { kind, term }
+  const sortQuery = currentQuery.sort
+
+  if (
+    typeof sortQuery === 'string' &&
+    isValidSortOption(sortQuery) &&
+    sortQuery !== DEFAULT_SORT_OPTION
+  ) {
+    query.sort = sortQuery
+  }
+
+  return query
 }
 
 /**

--- a/src/utils/sort.test.ts
+++ b/src/utils/sort.test.ts
@@ -113,6 +113,17 @@ describe('sortSearchResults – date', () => {
     expect(sorted[0].data.created_ts[0]).toBe('1000')
     expect(sorted[1].data.created_ts).toEqual([])
   })
+
+  it('places items with an unparseable date at the end', () => {
+    const invalidDate = makeResult({
+      resource_path: '/exposure/99/invalid.cellml',
+      description: ['Invalid date'],
+      created_ts: ['not-a-number'],
+    })
+    const sorted = sortSearchResults([invalidDate, resultA], 'date-asc')
+    expect(sorted[0].data.created_ts[0]).toBe('1000')
+    expect(sorted[1].resource_path).toBe('/exposure/99/invalid.cellml')
+  })
 })
 
 describe('sortSearchResults – does not mutate the original array', () => {

--- a/src/utils/sort.test.ts
+++ b/src/utils/sort.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import type { SearchResult } from '@/types/search'
+import { sortSearchResults } from '@/utils/sort'
+
+const makeResult = (overrides: Partial<SearchResult['data']> & { resource_path?: string }): SearchResult => ({
+  resource_path: overrides.resource_path ?? '/exposure/1/file.cellml',
+  data: {
+    aliased_uri: [],
+    cellml_keyword: [],
+    commit_authored_ts: [],
+    created_ts: overrides.created_ts ?? [],
+    description: overrides.description ?? [],
+    exposure_alias: [],
+    citation_author_family_name: [],
+    citation_id: [],
+    model_author: [],
+  },
+})
+
+const resultA = makeResult({ resource_path: '/exposure/10/a.cellml', description: ['Alpha model'], created_ts: ['1000'] })
+const resultB = makeResult({ resource_path: '/exposure/20/b.cellml', description: ['Beta model'],  created_ts: ['2000'] })
+const resultC = makeResult({ resource_path: '/exposure/5/c.cellml',  description: ['Gamma model'], created_ts: ['500']  })
+
+describe('sortSearchResults – description', () => {
+  it('sorts by description ascending', () => {
+    const sorted = sortSearchResults([resultC, resultB, resultA], 'description-asc')
+    expect(sorted.map((r) => r.data.description[0])).toEqual(['Alpha model', 'Beta model', 'Gamma model'])
+  })
+
+  it('sorts by description descending', () => {
+    const sorted = sortSearchResults([resultA, resultC, resultB], 'description-desc')
+    expect(sorted.map((r) => r.data.description[0])).toEqual(['Gamma model', 'Beta model', 'Alpha model'])
+  })
+
+  it('places items with null description at the end when sorting ascending', () => {
+    const nullDesc = makeResult({ resource_path: '/exposure/99/x.cellml' })
+    const sorted = sortSearchResults([nullDesc, resultA], 'description-asc')
+    expect(sorted[0].data.description[0]).toBe('Alpha model')
+    expect(sorted[1].data.description).toEqual([])
+  })
+
+  it('places items with null description at the end when sorting descending', () => {
+    const nullDesc = makeResult({ resource_path: '/exposure/99/x.cellml' })
+    const sorted = sortSearchResults([nullDesc, resultA], 'description-desc')
+    expect(sorted[0].data.description[0]).toBe('Alpha model')
+    expect(sorted[1].data.description).toEqual([])
+  })
+})
+
+describe('sortSearchResults – id', () => {
+  it('sorts by exposure ID ascending', () => {
+    const sorted = sortSearchResults([resultB, resultC, resultA], 'id-asc')
+    expect(sorted.map((r) => r.resource_path)).toEqual([
+      '/exposure/5/c.cellml',
+      '/exposure/10/a.cellml',
+      '/exposure/20/b.cellml',
+    ])
+  })
+
+  it('sorts by exposure ID descending', () => {
+    const sorted = sortSearchResults([resultA, resultC, resultB], 'id-desc')
+    expect(sorted.map((r) => r.resource_path)).toEqual([
+      '/exposure/20/b.cellml',
+      '/exposure/10/a.cellml',
+      '/exposure/5/c.cellml',
+    ])
+  })
+
+  it('places items with an unparseable ID at the end', () => {
+    const noId = makeResult({ resource_path: '/other/path/file.cellml', description: ['No ID'] })
+    const sorted = sortSearchResults([noId, resultA], 'id-asc')
+    expect(sorted[0].resource_path).toBe('/exposure/10/a.cellml')
+    expect(sorted[1].resource_path).toBe('/other/path/file.cellml')
+  })
+})
+
+describe('sortSearchResults – date', () => {
+  it('sorts by created_ts ascending', () => {
+    const sorted = sortSearchResults([resultB, resultA, resultC], 'date-asc')
+    expect(sorted.map((r) => r.data.created_ts[0])).toEqual(['500', '1000', '2000'])
+  })
+
+  it('sorts by created_ts descending', () => {
+    const sorted = sortSearchResults([resultC, resultA, resultB], 'date-desc')
+    expect(sorted.map((r) => r.data.created_ts[0])).toEqual(['2000', '1000', '500'])
+  })
+
+  it('places items without a date at the end', () => {
+    const noDate = makeResult({ resource_path: '/exposure/99/x.cellml', description: ['No date'] })
+    const sorted = sortSearchResults([noDate, resultA], 'date-asc')
+    expect(sorted[0].data.created_ts[0]).toBe('1000')
+    expect(sorted[1].data.created_ts).toEqual([])
+  })
+})
+
+describe('sortSearchResults – does not mutate the original array', () => {
+  it('returns a new array and leaves the source unchanged', () => {
+    const input = [resultC, resultA, resultB]
+    const sorted = sortSearchResults(input, 'description-asc')
+    expect(sorted).not.toBe(input)
+    expect(input[0].resource_path).toBe('/exposure/5/c.cellml')
+  })
+})

--- a/src/utils/sort.test.ts
+++ b/src/utils/sort.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest'
 import type { SearchResult } from '@/types/search'
 import { sortSearchResults } from '@/utils/sort'
 
-const makeResult = (overrides: Partial<SearchResult['data']> & { resource_path?: string }): SearchResult => ({
+const makeResult = (
+  overrides: Partial<SearchResult['data']> & { resource_path?: string },
+): SearchResult => ({
   resource_path: overrides.resource_path ?? '/exposure/1/file.cellml',
   data: {
     aliased_uri: [],
@@ -17,19 +19,39 @@ const makeResult = (overrides: Partial<SearchResult['data']> & { resource_path?:
   },
 })
 
-const resultA = makeResult({ resource_path: '/exposure/10/a.cellml', description: ['Alpha model'], created_ts: ['1000'] })
-const resultB = makeResult({ resource_path: '/exposure/20/b.cellml', description: ['Beta model'],  created_ts: ['2000'] })
-const resultC = makeResult({ resource_path: '/exposure/5/c.cellml',  description: ['Gamma model'], created_ts: ['500']  })
+const resultA = makeResult({
+  resource_path: '/exposure/10/a.cellml',
+  description: ['Alpha model'],
+  created_ts: ['1000'],
+})
+const resultB = makeResult({
+  resource_path: '/exposure/20/b.cellml',
+  description: ['Beta model'],
+  created_ts: ['2000'],
+})
+const resultC = makeResult({
+  resource_path: '/exposure/5/c.cellml',
+  description: ['Gamma model'],
+  created_ts: ['500'],
+})
 
 describe('sortSearchResults – description', () => {
   it('sorts by description ascending', () => {
     const sorted = sortSearchResults([resultC, resultB, resultA], 'description-asc')
-    expect(sorted.map((r) => r.data.description[0])).toEqual(['Alpha model', 'Beta model', 'Gamma model'])
+    expect(sorted.map((r) => r.data.description[0])).toEqual([
+      'Alpha model',
+      'Beta model',
+      'Gamma model',
+    ])
   })
 
   it('sorts by description descending', () => {
     const sorted = sortSearchResults([resultA, resultC, resultB], 'description-desc')
-    expect(sorted.map((r) => r.data.description[0])).toEqual(['Gamma model', 'Beta model', 'Alpha model'])
+    expect(sorted.map((r) => r.data.description[0])).toEqual([
+      'Gamma model',
+      'Beta model',
+      'Alpha model',
+    ])
   })
 
   it('places items with null description at the end when sorting ascending', () => {

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -1,4 +1,6 @@
 import type { SortableEntity, SortOption } from '@/types/common'
+import type { SearchResult } from '@/types/search'
+import { getExposureIdFromResourcePath } from '@/utils/exposure'
 
 /**
  * Grouped sort options for dropdown with two groups: Fields and Direction
@@ -41,6 +43,78 @@ export const isValidSortOption = (value: unknown): value is SortOption => {
   const directions =
     SORT_OPTIONS_GROUPED.find((g) => g.group === 'Direction')?.options.map((o) => o.value) ?? []
   return fields.some((f) => directions.some((d) => `${f}-${d}` === value))
+}
+
+/**
+ * Sorting function for search results, which use a different data shape to SortableEntity.
+ */
+export function sortSearchResults(items: SearchResult[], sortBy: SortOption): SearchResult[] {
+  return [...items].sort((a, b) => {
+    switch (sortBy) {
+      case 'description-asc': {
+        const descA = a.data.description?.[0] ?? null
+        const descB = b.data.description?.[0] ?? null
+
+        if (descA === null && descB === null) return 0
+        if (descA === null) return 1
+        if (descB === null) return -1
+
+        return descA.localeCompare(descB)
+      }
+      case 'description-desc': {
+        const descA = a.data.description?.[0] ?? null
+        const descB = b.data.description?.[0] ?? null
+
+        if (descA === null && descB === null) return 0
+        if (descA === null) return 1
+        if (descB === null) return -1
+
+        return descB.localeCompare(descA)
+      }
+      case 'id-asc': {
+        const idA = getExposureIdFromResourcePath(a.resource_path)
+        const idB = getExposureIdFromResourcePath(b.resource_path)
+
+        if (idA === null && idB === null) return 0
+        if (idA === null) return 1
+        if (idB === null) return -1
+
+        return idA - idB
+      }
+      case 'id-desc': {
+        const idA = getExposureIdFromResourcePath(a.resource_path)
+        const idB = getExposureIdFromResourcePath(b.resource_path)
+
+        if (idA === null && idB === null) return 0
+        if (idA === null) return 1
+        if (idB === null) return -1
+
+        return idB - idA
+      }
+      case 'date-asc': {
+        const dateA = a.data.created_ts?.[0] != null ? Number(a.data.created_ts[0]) : null
+        const dateB = b.data.created_ts?.[0] != null ? Number(b.data.created_ts[0]) : null
+
+        if (dateA === null && dateB === null) return 0
+        if (dateA === null) return 1
+        if (dateB === null) return -1
+
+        return dateA - dateB
+      }
+      case 'date-desc': {
+        const dateA = a.data.created_ts?.[0] != null ? Number(a.data.created_ts[0]) : null
+        const dateB = b.data.created_ts?.[0] != null ? Number(b.data.created_ts[0]) : null
+
+        if (dateA === null && dateB === null) return 0
+        if (dateA === null) return 1
+        if (dateB === null) return -1
+
+        return dateB - dateA
+      }
+      default:
+        return 0
+    }
+  })
 }
 
 /**

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -65,7 +65,11 @@ const compareNullableNumber = (a: number | null, b: number | null, desc = false)
   return desc ? b - a : a - b
 }
 
-const sortByValues = <T>(items: T[], sortBy: SortOption, getValues: (item: T) => SortValues): T[] => {
+const sortByValues = <T>(
+  items: T[],
+  sortBy: SortOption,
+  getValues: (item: T) => SortValues,
+): T[] => {
   return [...items].sort((a, b) => {
     const valuesA = getValues(a)
     const valuesB = getValues(b)

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -30,6 +30,12 @@ export const SORT_OPTIONS_GROUPED: SortOptionGroup[] = [
 
 export const DEFAULT_SORT_OPTION: SortOption = 'description-asc'
 
+interface SortValues {
+  description: string | null
+  id: number | null
+  date: number | null
+}
+
 /**
  * Returns true if the given runtime value is a valid SortOption.
  */
@@ -45,74 +51,64 @@ export const isValidSortOption = (value: unknown): value is SortOption => {
   return fields.some((f) => directions.some((d) => `${f}-${d}` === value))
 }
 
+const compareNullableString = (a: string | null, b: string | null, desc = false): number => {
+  if (a === null && b === null) return 0
+  if (a === null) return 1
+  if (b === null) return -1
+  return desc ? b.localeCompare(a) : a.localeCompare(b)
+}
+
+const compareNullableNumber = (a: number | null, b: number | null, desc = false): number => {
+  if (a === null && b === null) return 0
+  if (a === null) return 1
+  if (b === null) return -1
+  return desc ? b - a : a - b
+}
+
+const sortByValues = <T>(items: T[], sortBy: SortOption, getValues: (item: T) => SortValues): T[] => {
+  return [...items].sort((a, b) => {
+    const valuesA = getValues(a)
+    const valuesB = getValues(b)
+
+    switch (sortBy) {
+      case 'description-asc':
+        return compareNullableString(valuesA.description, valuesB.description)
+      case 'description-desc':
+        return compareNullableString(valuesA.description, valuesB.description, true)
+      case 'id-asc':
+        return compareNullableNumber(valuesA.id, valuesB.id)
+      case 'id-desc':
+        return compareNullableNumber(valuesA.id, valuesB.id, true)
+      case 'date-asc':
+        return compareNullableNumber(valuesA.date, valuesB.date)
+      case 'date-desc':
+        return compareNullableNumber(valuesA.date, valuesB.date, true)
+      default:
+        return 0
+    }
+  })
+}
+
+const parseNullableNumber = (value: unknown): number | null => {
+  if (value === null || value === undefined) {
+    return null
+  }
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
 /**
  * Sorting function for search results, which use a different data shape to SortableEntity.
  */
 export function sortSearchResults(items: SearchResult[], sortBy: SortOption): SearchResult[] {
-  return [...items].sort((a, b) => {
-    switch (sortBy) {
-      case 'description-asc': {
-        const descA = a.data.description?.[0] ?? null
-        const descB = b.data.description?.[0] ?? null
+  return sortByValues(items, sortBy, (item) => {
+    const createdTs = item.data.created_ts?.[0] ?? null
 
-        if (descA === null && descB === null) return 0
-        if (descA === null) return 1
-        if (descB === null) return -1
-
-        return descA.localeCompare(descB)
-      }
-      case 'description-desc': {
-        const descA = a.data.description?.[0] ?? null
-        const descB = b.data.description?.[0] ?? null
-
-        if (descA === null && descB === null) return 0
-        if (descA === null) return 1
-        if (descB === null) return -1
-
-        return descB.localeCompare(descA)
-      }
-      case 'id-asc': {
-        const idA = getExposureIdFromResourcePath(a.resource_path)
-        const idB = getExposureIdFromResourcePath(b.resource_path)
-
-        if (idA === null && idB === null) return 0
-        if (idA === null) return 1
-        if (idB === null) return -1
-
-        return idA - idB
-      }
-      case 'id-desc': {
-        const idA = getExposureIdFromResourcePath(a.resource_path)
-        const idB = getExposureIdFromResourcePath(b.resource_path)
-
-        if (idA === null && idB === null) return 0
-        if (idA === null) return 1
-        if (idB === null) return -1
-
-        return idB - idA
-      }
-      case 'date-asc': {
-        const dateA = a.data.created_ts?.[0] != null ? Number(a.data.created_ts[0]) : null
-        const dateB = b.data.created_ts?.[0] != null ? Number(b.data.created_ts[0]) : null
-
-        if (dateA === null && dateB === null) return 0
-        if (dateA === null) return 1
-        if (dateB === null) return -1
-
-        return dateA - dateB
-      }
-      case 'date-desc': {
-        const dateA = a.data.created_ts?.[0] != null ? Number(a.data.created_ts[0]) : null
-        const dateB = b.data.created_ts?.[0] != null ? Number(b.data.created_ts[0]) : null
-
-        if (dateA === null && dateB === null) return 0
-        if (dateA === null) return 1
-        if (dateB === null) return -1
-
-        return dateB - dateA
-      }
-      default:
-        return 0
+    return {
+      description: item.data.description?.[0] ?? null,
+      id: getExposureIdFromResourcePath(item.resource_path),
+      date: parseNullableNumber(createdTs),
     }
   })
 }
@@ -121,38 +117,11 @@ export function sortSearchResults(items: SearchResult[], sortBy: SortOption): Se
  * Generic sorting function for entities with id, description, and created_ts.
  */
 export function sortEntities<T extends SortableEntity>(items: T[], sortBy: SortOption): T[] {
-  return [...items].sort((a: T, b: T) => {
-    switch (sortBy) {
-      case 'description-asc': {
-        const descA = a.entity.description
-        const descB = b.entity.description
-
-        if (descA === null && descB === null) return 0
-        if (descA === null) return 1
-        if (descB === null) return -1
-
-        return descA.localeCompare(descB)
-      }
-      case 'description-desc': {
-        const descA = a.entity.description
-        const descB = b.entity.description
-
-        if (descA === null && descB === null) return 0
-        if (descA === null) return 1
-        if (descB === null) return -1
-
-        return descB.localeCompare(descA)
-      }
-      case 'id-asc':
-        return a.entity.id - b.entity.id
-      case 'id-desc':
-        return b.entity.id - a.entity.id
-      case 'date-asc':
-        return a.entity.created_ts - b.entity.created_ts
-      case 'date-desc':
-        return b.entity.created_ts - a.entity.created_ts
-      default:
-        return 0
+  return sortByValues(items, sortBy, (item) => {
+    return {
+      description: item.entity.description,
+      id: item.entity.id,
+      date: item.entity.created_ts,
     }
   })
 }


### PR DESCRIPTION
Fixes #120 and #82.

### Changes

- Sorting has been added to search results, the same function as in `exposures` and `workspaces`. 

The updates are available on https://akhuoa.github.io/pmrapp-frontend/search?kind=citation_author_family_name&term=Noble&sort=id-asc for testing.
