### PR TITLE
Fix empty fields in Mathematics view 

### DIFF
--- a/src/components/organisms/ExposureDetail.test.ts
+++ b/src/components/organisms/ExposureDetail.test.ts
@@ -29,6 +29,7 @@ describe('ExposureDetail', () => {
     props = {},
     stubs = {},
     generatedCode = '',
+    mathsJSON = '[]',
   }: {
     props?: Partial<{
       alias: string
@@ -37,6 +38,7 @@ describe('ExposureDetail', () => {
     }>
     stubs?: Record<string, unknown>
     generatedCode?: string
+    mathsJSON?: string
   } = {}) => {
     vi.spyOn(exposureStore, 'getExposureInfo').mockResolvedValue(mockExposureInfo)
     vi.spyOn(exposureStore, 'getExposureSafeHTML').mockImplementation(
@@ -49,7 +51,7 @@ describe('ExposureDetail', () => {
     vi.spyOn(exposureStore, 'getExposureRawContent').mockImplementation(
       async (_id, _fileId, _view, filename) => {
         if (filename === 'cmeta.json') return JSON.stringify(mockMetadata)
-        if (filename === 'math.json') return '[]'
+        if (filename === 'math.json') return mathsJSON
         if (filename === 'code.C.c') return generatedCode
         return ''
       },
@@ -448,5 +450,52 @@ describe('ExposureDetail', () => {
 
     const sectionContent = sectionHeading?.element.nextElementSibling?.textContent
     expect(sectionContent).toContain('CC BY 3.0')
+  })
+
+  describe('cellml_math view', () => {
+    it('filters out entries with empty math arrays and renders only non-empty ones', async () => {
+      const mathData = JSON.stringify([
+        ['Component A', ['<math>x</math>', '<math>y</math>']],
+        ['Component B', []],
+        ['Component C', ['<math>z</math>']],
+      ])
+
+      const wrapper = await mountComponent({
+        props: { view: 'cellml_math' },
+        mathsJSON: mathData,
+      })
+
+      const mathBox = wrapper.find('.box.overflow-auto')
+      expect(mathBox.exists()).toBe(true)
+
+      // Only the two non-empty components should have headings.
+      const sectionHeadings = mathBox.findAll('h4')
+      expect(sectionHeadings).toHaveLength(2)
+      expect(sectionHeadings[0].text()).toBe('Component A')
+      expect(sectionHeadings[1].text()).toBe('Component C')
+
+      // The empty-array entry title must not appear.
+      expect(mathBox.text()).not.toContain('Component B')
+    })
+
+    it('shows empty-state message and not the HTML view when all math sections are filtered out', async () => {
+      const mathData = JSON.stringify([
+        ['Component A', []],
+        ['Component B', []],
+      ])
+
+      const wrapper = await mountComponent({
+        props: { view: 'cellml_math' },
+        mathsJSON: mathData,
+      })
+
+      // Empty-state message must be visible.
+      const emptyMessage = wrapper.find('p.text-sm')
+      expect(emptyMessage.exists()).toBe(true)
+      expect(emptyMessage.text()).toBe('No mathematics content available.')
+
+      // Must NOT fall through to the detailHTML block.
+      expect(wrapper.find('.html-view').exists()).toBe(false)
+    })
   })
 })

--- a/src/components/organisms/ExposureDetail.test.ts
+++ b/src/components/organisms/ExposureDetail.test.ts
@@ -465,7 +465,7 @@ describe('ExposureDetail', () => {
         mathsJSON: mathData,
       })
 
-      const mathBox = wrapper.find('.box.overflow-auto')
+      const mathBox = wrapper.find('.box')
       expect(mathBox.exists()).toBe(true)
 
       // Only the two non-empty components should have headings.

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -257,9 +257,7 @@ const generateMath = async () => {
     const parsedMaths = JSON.parse(response)
     mathsJSON.value = Array.isArray(parsedMaths)
       ? parsedMaths.filter(
-          (value): value is [string, string[]] =>
-            Array.isArray(value[1]) &&
-            value[1].length > 0,
+          (value): value is [string, string[]] => Array.isArray(value[1]) && value[1].length > 0,
         )
       : []
   } catch (err) {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -536,7 +536,7 @@ onMounted(async () => {
         </div>
       </div>
 
-      <div v-else-if="props.view === 'cellml_math'" class="box overflow-auto">
+      <div v-else-if="props.view === 'cellml_math'" class="box">
         <p v-if="!mathsJSON.length" class="text-sm text-gray-500 dark:text-gray-400">No mathematics content available.</p>
         <template v-else>
           <div v-for="value in mathsJSON" :key="value[0]"
@@ -544,7 +544,7 @@ onMounted(async () => {
           >
             <h4 class="font-semibold mb-4">{{ value[0] }}</h4>
             <div v-for="math in value[1]" :key="math">
-              <div v-html="math" class="text-sm math-view"></div>
+              <div v-html="math" class="math-view"></div>
             </div>
           </div>
         </template>
@@ -911,6 +911,8 @@ onMounted(async () => {
 }
 
 .math-view {
+  @apply p-2 text-center text-sm overflow-auto;
+
   & :deep(math) {
     @apply flex flex-col gap-4;
   }

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -254,7 +254,14 @@ const generateMath = async () => {
       'cellml_math',
       'math.json',
     )
-    mathsJSON.value = JSON.parse(response)
+    const parsedMaths = JSON.parse(response)
+    mathsJSON.value = Array.isArray(parsedMaths)
+      ? parsedMaths.filter(
+          (value): value is [string, string[]] =>
+            Array.isArray(value[1]) &&
+            value[1].length > 0,
+        )
+      : []
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : 'Failed to parse mathematics data.'
     error.value = {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -255,11 +255,12 @@ const generateMath = async () => {
       'math.json',
     )
     const mathResponseJSON = JSON.parse(response)
-    mathsJSON.value = Array.isArray(mathResponseJSON)
+    const filteredMathsJSON = Array.isArray(mathResponseJSON)
       ? mathResponseJSON.filter(
           (value): value is [string, string[]] => Array.isArray(value[1]) && value[1].length > 0,
         )
       : []
+    mathsJSON.value = filteredMathsJSON
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : 'Failed to parse mathematics data.'
     error.value = {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -535,15 +535,18 @@ onMounted(async () => {
         </div>
       </div>
 
-      <div v-else-if="props.view === 'cellml_math' && mathsJSON.length" class="box overflow-auto">
-        <div v-for="value in mathsJSON" :key="value[0]"
-          class="mb-6 pb-6 last:mb-0 last:pb-0 border-b border-gray-200 dark:border-gray-700 last:border-0"
-        >
-          <h4 class="font-semibold mb-4">{{ value[0] }}</h4>
-          <div v-for="math in value[1]" :key="math">
-            <div v-html="math" class="text-sm math-view"></div>
+      <div v-else-if="props.view === 'cellml_math'" class="box overflow-auto">
+        <p v-if="!mathsJSON.length" class="text-sm text-gray-500 dark:text-gray-400">No mathematics content available.</p>
+        <template v-else>
+          <div v-for="value in mathsJSON" :key="value[0]"
+            class="mb-6 pb-6 last:mb-0 last:pb-0 border-b border-gray-200 dark:border-gray-700 last:border-0"
+          >
+            <h4 class="font-semibold mb-4">{{ value[0] }}</h4>
+            <div v-for="math in value[1]" :key="math">
+              <div v-html="math" class="text-sm math-view"></div>
+            </div>
           </div>
-        </div>
+        </template>
       </div>
 
       <div v-else-if="detailHTML" class="box">

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -254,9 +254,9 @@ const generateMath = async () => {
       'cellml_math',
       'math.json',
     )
-    const parsedMaths = JSON.parse(response)
-    mathsJSON.value = Array.isArray(parsedMaths)
-      ? parsedMaths.filter(
+    const mathResponseJSON = JSON.parse(response)
+    mathsJSON.value = Array.isArray(mathResponseJSON)
+      ? mathResponseJSON.filter(
           (value): value is [string, string[]] => Array.isArray(value[1]) && value[1].length > 0,
         )
       : []


### PR DESCRIPTION
Fixes #127.

The empty fields in Mathematics have been filtered out.

**Before the fix:**
https://pmrapp-frontend.pages.dev/pmrapp-frontend/exposures/7e3/bhalla_iyengar_1999_a.cellml/cellml_math

**After the fix:**
https://akhuoa.github.io/pmrapp-frontend/exposures/7e3/bhalla_iyengar_1999_a.cellml/cellml_math