### PR TITLE
Fix website freeze on syntax highlighting on large file 

### DIFF
--- a/src/components/atoms/CodeBlock.test.ts
+++ b/src/components/atoms/CodeBlock.test.ts
@@ -54,6 +54,7 @@ const smallCode = 'const x = 1'
 
 describe('CodeBlock', () => {
   afterEach(() => {
+    vi.unstubAllGlobals()
     vi.clearAllMocks()
   })
 

--- a/src/components/atoms/CodeBlock.test.ts
+++ b/src/components/atoms/CodeBlock.test.ts
@@ -50,10 +50,7 @@ beforeEach(() => {
   )
 })
 
-const MAX_HIGHLIGHT_SIZE_BYTES = 500 * 1024 // 500 KB – mirrors the constant in CodeBlock.vue
-
 const smallCode = 'const x = 1'
-const largeCode = 'x'.repeat(MAX_HIGHLIGHT_SIZE_BYTES + 1)
 
 describe('CodeBlock', () => {
   afterEach(() => {
@@ -68,37 +65,11 @@ describe('CodeBlock', () => {
     wrapper.unmount()
   })
 
-  it('includes the line-numbers class for small files', () => {
+  it('includes the line-numbers class', () => {
     const wrapper = mount(CodeBlock, {
       props: { code: smallCode, filename: 'example.py' },
     })
     expect(wrapper.find('pre').classes()).toContain('line-numbers')
-    wrapper.unmount()
-  })
-
-  it('does not include line-numbers class for large files', () => {
-    const wrapper = mount(CodeBlock, {
-      props: { code: largeCode, filename: 'model.cellml' },
-    })
-    expect(wrapper.find('pre').classes()).not.toContain('line-numbers')
-    wrapper.unmount()
-  })
-
-  it('shows warning notice for large files', () => {
-    const wrapper = mount(CodeBlock, {
-      props: { code: largeCode, filename: 'model.cellml' },
-    })
-    const notice = wrapper.find('[class*="bg-amber"]')
-    expect(notice.exists()).toBe(true)
-    expect(notice.text()).toContain('too large for syntax highlighting')
-    wrapper.unmount()
-  })
-
-  it('does not show warning notice for small files', () => {
-    const wrapper = mount(CodeBlock, {
-      props: { code: smallCode, filename: 'model.cellml' },
-    })
-    expect(wrapper.find('[class*="bg-amber"]').exists()).toBe(false)
     wrapper.unmount()
   })
 
@@ -118,31 +89,17 @@ describe('CodeBlock', () => {
     wrapper.unmount()
   })
 
-  it('updates warning visibility when code changes from small to large', async () => {
+  it('updates code when props change', async () => {
     const wrapper = mount(CodeBlock, {
       props: { code: smallCode, filename: 'model.cellml' },
     })
 
-    expect(wrapper.find('[class*="bg-amber"]').exists()).toBe(false)
+    expect(wrapper.find('code').text()).toBe(smallCode)
 
-    await wrapper.setProps({ code: largeCode })
+    await wrapper.setProps({ code: 'new code' })
     await wrapper.vm.$nextTick()
 
-    expect(wrapper.find('[class*="bg-amber"]').exists()).toBe(true)
-    wrapper.unmount()
-  })
-
-  it('removes warning when code changes from large to small', async () => {
-    const wrapper = mount(CodeBlock, {
-      props: { code: largeCode, filename: 'model.cellml' },
-    })
-
-    expect(wrapper.find('[class*="bg-amber"]').exists()).toBe(true)
-
-    await wrapper.setProps({ code: smallCode })
-    await wrapper.vm.$nextTick()
-
-    expect(wrapper.find('[class*="bg-amber"]').exists()).toBe(false)
+    expect(wrapper.find('code').text()).toBe('new code')
     wrapper.unmount()
   })
 })

--- a/src/components/atoms/CodeBlock.test.ts
+++ b/src/components/atoms/CodeBlock.test.ts
@@ -1,0 +1,148 @@
+import { mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import CodeBlock from '@/components/atoms/CodeBlock.vue'
+
+// Mock PrismJS to avoid real syntax highlighting in tests.
+vi.mock('prismjs', () => ({
+  default: {
+    highlightElement: vi.fn(),
+    plugins: {
+      lineNumbers: {
+        resize: vi.fn(),
+      },
+    },
+  },
+}))
+
+// Mock PrismJS language and plugin imports.
+vi.mock('prismjs/components/prism-markup', () => ({}))
+vi.mock('prismjs/components/prism-css', () => ({}))
+vi.mock('prismjs/components/prism-c', () => ({}))
+vi.mock('prismjs/components/prism-cpp', () => ({}))
+vi.mock('prismjs/components/prism-fortran', () => ({}))
+vi.mock('prismjs/components/prism-javascript', () => ({}))
+vi.mock('prismjs/components/prism-json', () => ({}))
+vi.mock('prismjs/components/prism-python', () => ({}))
+vi.mock('prismjs/components/prism-markdown', () => ({}))
+vi.mock('prismjs/components/prism-matlab', () => ({}))
+vi.mock('prismjs/plugins/line-numbers/prism-line-numbers.css', () => ({}))
+vi.mock('prismjs/plugins/line-numbers/prism-line-numbers', () => ({}))
+vi.mock('prismjs/themes/prism-okaidia.css?url', () => ({ default: '' }))
+vi.mock('prismjs/themes/prism.css?url', () => ({ default: '' }))
+
+beforeEach(() => {
+  // ResizeObserver must be a proper constructor for the component's typeof check.
+  class MockResizeObserver {
+    observe = vi.fn()
+    disconnect = vi.fn()
+  }
+  vi.stubGlobal('ResizeObserver', MockResizeObserver)
+
+  // jsdom does not implement matchMedia; provide a minimal stub.
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    })),
+  )
+})
+
+const MAX_HIGHLIGHT_SIZE_BYTES = 500 * 1024 // 500 KB – mirrors the constant in CodeBlock.vue
+
+const smallCode = 'const x = 1'
+const largeCode = 'x'.repeat(MAX_HIGHLIGHT_SIZE_BYTES + 1)
+
+describe('CodeBlock', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders code content', () => {
+    const wrapper = mount(CodeBlock, {
+      props: { code: smallCode, filename: 'example.js' },
+    })
+    expect(wrapper.find('code').text()).toBe(smallCode)
+    wrapper.unmount()
+  })
+
+  it('includes the line-numbers class for small files', () => {
+    const wrapper = mount(CodeBlock, {
+      props: { code: smallCode, filename: 'example.py' },
+    })
+    expect(wrapper.find('pre').classes()).toContain('line-numbers')
+    wrapper.unmount()
+  })
+
+  it('does not include line-numbers class for large files', () => {
+    const wrapper = mount(CodeBlock, {
+      props: { code: largeCode, filename: 'model.cellml' },
+    })
+    expect(wrapper.find('pre').classes()).not.toContain('line-numbers')
+    wrapper.unmount()
+  })
+
+  it('shows warning notice for large files', () => {
+    const wrapper = mount(CodeBlock, {
+      props: { code: largeCode, filename: 'model.cellml' },
+    })
+    const notice = wrapper.find('[class*="bg-amber"]')
+    expect(notice.exists()).toBe(true)
+    expect(notice.text()).toContain('too large for syntax highlighting')
+    wrapper.unmount()
+  })
+
+  it('does not show warning notice for small files', () => {
+    const wrapper = mount(CodeBlock, {
+      props: { code: smallCode, filename: 'model.cellml' },
+    })
+    expect(wrapper.find('[class*="bg-amber"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('applies the correct language class for .cellml files', () => {
+    const wrapper = mount(CodeBlock, {
+      props: { code: smallCode, filename: 'model.cellml' },
+    })
+    expect(wrapper.find('code').classes()).toContain('language-markup')
+    wrapper.unmount()
+  })
+
+  it('applies plaintext language class for unknown extensions', () => {
+    const wrapper = mount(CodeBlock, {
+      props: { code: smallCode, filename: 'data.xyz' },
+    })
+    expect(wrapper.find('code').classes()).toContain('language-plaintext')
+    wrapper.unmount()
+  })
+
+  it('updates warning visibility when code changes from small to large', async () => {
+    const wrapper = mount(CodeBlock, {
+      props: { code: smallCode, filename: 'model.cellml' },
+    })
+
+    expect(wrapper.find('[class*="bg-amber"]').exists()).toBe(false)
+
+    await wrapper.setProps({ code: largeCode })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[class*="bg-amber"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('removes warning when code changes from large to small', async () => {
+    const wrapper = mount(CodeBlock, {
+      props: { code: largeCode, filename: 'model.cellml' },
+    })
+
+    expect(wrapper.find('[class*="bg-amber"]').exists()).toBe(true)
+
+    await wrapper.setProps({ code: smallCode })
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('[class*="bg-amber"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})

--- a/src/components/atoms/CodeBlock.vue
+++ b/src/components/atoms/CodeBlock.vue
@@ -15,9 +15,6 @@ import 'prismjs/components/prism-matlab'
 import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
 import 'prismjs/plugins/line-numbers/prism-line-numbers'
 
-// Files larger than this threshold will not be syntax-highlighted to prevent browser freeze.
-const MAX_HIGHLIGHT_SIZE_BYTES = 500 * 1024 // 500 KB
-
 const props = defineProps<{
   code: string
   filename: string
@@ -29,11 +26,9 @@ const darkThemeMediaQuery = ref<MediaQueryList | null>(null)
 const isWrapped = ref(false)
 let observer: ResizeObserver | null = null
 
-const isTooLargeForHighlighting = computed(() => props.code.length > MAX_HIGHLIGHT_SIZE_BYTES)
-
 const preformatClass = computed(() =>
   [
-    ...(!isTooLargeForHighlighting.value ? ['line-numbers'] : []),
+    'line-numbers',
     'bg-gray-50',
     'dark:bg-gray-900',
     'rounded',
@@ -90,7 +85,7 @@ const highlightCode = async () => {
       // Clear previous highlighting.
       codeBlock.value.removeAttribute('data-highlighted')
 
-      if (detectedLanguage.value !== 'none' && !isTooLargeForHighlighting.value) {
+      if (detectedLanguage.value !== 'none') {
         Prism.highlightElement(codeBlock.value)
       }
     } catch (err) {
@@ -212,21 +207,13 @@ watch(
 </script>
 
 <template>
-  <div>
-    <div
-      v-if="isTooLargeForHighlighting"
-      class="bg-amber-50 dark:bg-amber-900/20 px-3 py-2 text-sm text-amber-800 dark:text-amber-200"
-    >
-      ⚠️ This file is too large for syntax highlighting. Displaying raw content.
-    </div>
-    <pre
-      ref="preBlock"
-      :class="preformatClass"
-    ><code
-      ref="codeBlock"
-      :class="`language-${detectedLanguage}`"
-    >{{ code }}</code></pre>
-  </div>
+  <pre
+    ref="preBlock"
+    :class="preformatClass"
+  ><code
+    ref="codeBlock"
+    :class="`language-${detectedLanguage}`"
+  >{{ code }}</code></pre>
 </template>
 
 <style scoped>

--- a/src/components/atoms/CodeBlock.vue
+++ b/src/components/atoms/CodeBlock.vue
@@ -215,7 +215,7 @@ watch(
   <div>
     <div
       v-if="isTooLargeForHighlighting"
-      class="bg-amber-50 dark:bg-amber-900/20 border border-amber-300 dark:border-amber-700 rounded px-3 py-2 text-sm text-amber-800 dark:text-amber-200 mb-2"
+      class="bg-amber-50 dark:bg-amber-900/20 px-3 py-2 text-sm text-amber-800 dark:text-amber-200"
     >
       ⚠️ This file is too large for syntax highlighting. Displaying raw content.
     </div>

--- a/src/components/atoms/CodeBlock.vue
+++ b/src/components/atoms/CodeBlock.vue
@@ -15,6 +15,9 @@ import 'prismjs/components/prism-matlab'
 import 'prismjs/plugins/line-numbers/prism-line-numbers.css'
 import 'prismjs/plugins/line-numbers/prism-line-numbers'
 
+// Files larger than this threshold will not be syntax-highlighted to prevent browser freeze.
+const MAX_HIGHLIGHT_SIZE_BYTES = 500 * 1024 // 500 KB
+
 const props = defineProps<{
   code: string
   filename: string
@@ -26,18 +29,22 @@ const darkThemeMediaQuery = ref<MediaQueryList | null>(null)
 const isWrapped = ref(false)
 let observer: ResizeObserver | null = null
 
-const preformatClass = [
-  'line-numbers',
-  'bg-gray-50',
-  'dark:bg-gray-900',
-  'rounded',
-  'overflow-x-auto',
-  'text-sm!',
-  'm-0!',
-  'transition-all',
-  'duration-200',
-  'ease-in-out',
-].join(' ')
+const isTooLargeForHighlighting = computed(() => props.code.length > MAX_HIGHLIGHT_SIZE_BYTES)
+
+const preformatClass = computed(() =>
+  [
+    ...(!isTooLargeForHighlighting.value ? ['line-numbers'] : []),
+    'bg-gray-50',
+    'dark:bg-gray-900',
+    'rounded',
+    'overflow-x-auto',
+    'text-sm!',
+    'm-0!',
+    'transition-all',
+    'duration-200',
+    'ease-in-out',
+  ].join(' '),
+)
 
 const detectedLanguage = computed(() => {
   const ext = props.filename.split('.').pop()?.toLowerCase()
@@ -83,7 +90,7 @@ const highlightCode = async () => {
       // Clear previous highlighting.
       codeBlock.value.removeAttribute('data-highlighted')
 
-      if (detectedLanguage.value !== 'none') {
+      if (detectedLanguage.value !== 'none' && !isTooLargeForHighlighting.value) {
         Prism.highlightElement(codeBlock.value)
       }
     } catch (err) {
@@ -100,6 +107,9 @@ const syncWrapAndLineNumbers = async () => {
   codeBlock.value.classList.toggle('!whitespace-pre-wrap', isWrapped.value)
 
   await nextTick()
+
+  // Re-check refs after await in case the component was unmounted.
+  if (!preBlock.value) return
 
   if (!isWrapped.value) {
     const lineSpans = preBlock.value.querySelectorAll('.line-numbers-rows > span')
@@ -203,6 +213,12 @@ watch(
 
 <template>
   <div>
+    <div
+      v-if="isTooLargeForHighlighting"
+      class="bg-amber-50 dark:bg-amber-900/20 border border-amber-300 dark:border-amber-700 rounded px-3 py-2 text-sm text-amber-800 dark:text-amber-200 mb-2"
+    >
+      ⚠️ This file is too large for syntax highlighting. Displaying raw content.
+    </div>
     <pre
       ref="preBlock"
       :class="preformatClass"

--- a/src/components/molecules/UserDropdown.vue
+++ b/src/components/molecules/UserDropdown.vue
@@ -18,7 +18,7 @@ const showLogoutConfirm = ref(false)
 
 const menuId = 'user-dropdown-menu'
 const buttonLabel = computed(() =>
-  authStore.username ? `${authStore.username} – user menu` : 'User menu'
+  authStore.username ? `${authStore.username} – user menu` : 'User menu',
 )
 
 const toggleDropdown = () => {

--- a/src/components/organisms/Login.vue
+++ b/src/components/organisms/Login.vue
@@ -3,9 +3,9 @@
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import ActionButton from '@/components/atoms/ActionButton.vue'
+import CloseButton from '@/components/atoms/CloseButton.vue'
 import { getAuthService } from '@/services'
 import { useAuthStore } from '@/stores/auth'
-import CloseButton from '@/components/atoms/CloseButton.vue'
 import { useGlobalStateStore } from '@/stores/globalState'
 
 const router = useRouter()

--- a/src/components/organisms/Login.vue
+++ b/src/components/organisms/Login.vue
@@ -52,7 +52,7 @@ watch(
 
     focusUsernameInput()
     globalStateStore.consumeLoginUsernameFocus()
-  }
+  },
 )
 
 watch(error, (newError) => {

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -18,6 +18,10 @@ import { isCodeFile, isImageFile, isMarkdownFile, isPdfFile, isSvgFile } from '@
 import { renderMarkdown } from '@/utils/markdown'
 import ActionButton from '../atoms/ActionButton.vue'
 
+// Files with text length above this threshold are not rendered in the preview to prevent browser freeze.
+// This uses JavaScript string length (UTF-16 code units), not exact file size in bytes.
+const MAX_PREVIEW_TEXT_LENGTH = 500 * 1024 // ~500KB
+
 const props = defineProps<{
   alias: string
   commitId: string
@@ -74,6 +78,9 @@ const imageDataUrl = computed(() => {
   if (!isImage.value) return ''
   return fileBlobUrl.value
 })
+
+// Fast guard: avoid rendering very large text payloads in the browser preview.
+const isTooLargeForPreview = computed(() => fileContent.value.length > MAX_PREVIEW_TEXT_LENGTH)
 
 const downloadFile = () => {
   if (isImage.value || isSvg.value || isPDF.value) {
@@ -162,13 +169,13 @@ onBeforeUnmount(() => {
             {{ showCode ? 'Preview' : 'Code' }}
           </button>
           <WrapButton
-            v-if="shouldShowAsText"
+            v-if="shouldShowAsText && !isTooLargeForPreview"
             :disabled="(isSvg || isMarkdown) ? !showCode : false"
             :active="codeBlockRef?.isWrapped"
             @click="toggleCodeWrap"
           />
           <CopyButton
-            v-if="shouldShowAsText"
+            v-if="shouldShowAsText && !isTooLargeForPreview"
             :text="fileContent"
             title="Copy code"
           />
@@ -203,6 +210,20 @@ onBeforeUnmount(() => {
       <!-- PDF View -->
       <div v-else-if="isPDF" class="flex justify-center">
         <embed :src="fileBlobUrl" type="application/pdf" width="100%" height="800px" />
+      </div>
+
+      <!-- Code/Text View (Too Large) -->
+      <div v-else-if="shouldShowAsText && isTooLargeForPreview" class="text-center py-8 text-gray-500 dark:text-gray-400">
+        <p class="mb-4">This file is too large to preview in the browser.</p>
+        <ActionButton
+          variant="primary"
+          size="lg"
+          @click="downloadFile"
+          content-section="Workspace File Detail"
+        >
+          <DownloadIcon class="w-4 h-4" />
+          Download
+        </ActionButton>
       </div>
 
       <!-- Code/Text View -->

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -13,7 +13,7 @@ import ErrorBlock from '@/components/molecules/ErrorBlock.vue'
 import PageHeader from '@/components/molecules/PageHeader.vue'
 import { useBackNavigation } from '@/composables/useBackNavigation'
 import { getWorkspaceService } from '@/services'
-import { downloadFileFromBlob, downloadFileFromContent } from '@/utils/download'
+import { downloadFileFromBlob } from '@/utils/download'
 import { isCodeFile, isImageFile, isMarkdownFile, isPdfFile, isSvgFile } from '@/utils/file'
 import { renderMarkdown } from '@/utils/markdown'
 import ActionButton from '../atoms/ActionButton.vue'
@@ -83,11 +83,7 @@ const imageDataUrl = computed(() => {
 const isTooLargeForPreview = computed(() => fileSizeBytes.value > MAX_PREVIEW_FILE_SIZE_BYTES)
 
 const downloadFile = () => {
-  if (isImage.value || isSvg.value || isPDF.value || isTooLargeForPreview.value) {
-    downloadFileFromBlob(fileBlob.value, filename.value)
-  } else {
-    downloadFileFromContent(fileContent.value, filename.value)
-  }
+  downloadFileFromBlob(fileBlob.value, filename.value)
 }
 
 const toggleCodeView = () => {

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -18,9 +18,8 @@ import { isCodeFile, isImageFile, isMarkdownFile, isPdfFile, isSvgFile } from '@
 import { renderMarkdown } from '@/utils/markdown'
 import ActionButton from '../atoms/ActionButton.vue'
 
-// Files with text length above this threshold are not rendered in the preview to prevent browser freeze.
-// This uses JavaScript string length (UTF-16 code units), not exact file size in bytes.
-const MAX_PREVIEW_TEXT_LENGTH = 500 * 1024 // ~500KB
+// Files with size above this threshold are not rendered in the preview to prevent browser freeze.
+const MAX_PREVIEW_FILE_SIZE_BYTES = 500 * 1024 // ~500 KB
 
 const props = defineProps<{
   alias: string
@@ -31,6 +30,7 @@ const props = defineProps<{
 const fileContent = ref<string>('')
 const fileBlob = ref<Blob>(new Blob())
 const fileBlobUrl = ref<string>('')
+const fileSizeBytes = ref(0)
 const error = ref<string | null>(null)
 const isLoading = ref(true)
 const showCode = ref(false)
@@ -79,11 +79,11 @@ const imageDataUrl = computed(() => {
   return fileBlobUrl.value
 })
 
-// Fast guard: avoid rendering very large text payloads in the browser preview.
-const isTooLargeForPreview = computed(() => fileContent.value.length > MAX_PREVIEW_TEXT_LENGTH)
+// Fast guard: avoid rendering very large payloads in the browser preview.
+const isTooLargeForPreview = computed(() => fileSizeBytes.value > MAX_PREVIEW_FILE_SIZE_BYTES)
 
 const downloadFile = () => {
-  if (isImage.value || isSvg.value || isPDF.value) {
+  if (isImage.value || isSvg.value || isPDF.value || isTooLargeForPreview.value) {
     downloadFileFromBlob(fileBlob.value, filename.value)
   } else {
     downloadFileFromContent(fileContent.value, filename.value)
@@ -105,10 +105,11 @@ onMounted(async () => {
       props.commitId,
       props.path,
     )
+    fileBlob.value = blob
+    fileSizeBytes.value = blob.size
 
     // Image-like previews use an object URL from the blob.
     if (isImage.value || isSvg.value || isPDF.value) {
-      fileBlob.value = blob
       fileBlobUrl.value = URL.createObjectURL(blob)
 
       // For SVG, also get text content for code view.
@@ -116,8 +117,10 @@ onMounted(async () => {
         fileContent.value = await blob.text()
       }
     } else {
-      // Text-like previews decode the fetched blob into a string.
-      fileContent.value = await blob.text()
+      // Skip text decode for oversized code-like previews; download remains available via blob.
+      if (!isTooLargeForPreview.value || isMarkdown.value) {
+        fileContent.value = await blob.text()
+      }
     }
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Failed to load file.'

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -96,11 +96,7 @@ const toggleCodeWrap = () => {
 
 onMounted(async () => {
   try {
-    const blob = await getWorkspaceService().getRawFileBlob(
-      props.alias,
-      props.commitId,
-      props.path,
-    )
+    const blob = await getWorkspaceService().getRawFileBlob(props.alias, props.commitId, props.path)
     fileBlob.value = blob
     fileSizeBytes.value = blob.size
 

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -115,12 +115,13 @@ onMounted(async () => {
         fileContent.value = await blob.text()
       }
     } else {
-      // Fetch text files as text.
-      fileContent.value = await getWorkspaceService().getRawFile(
+      // Fetch text files through blob endpoint and decode to text.
+      const blob = await getWorkspaceService().getRawFileBlob(
         props.alias,
         props.commitId,
         props.path,
       )
+      fileContent.value = await blob.text()
     }
   } catch (err) {
     error.value = err instanceof Error ? err.message : 'Failed to load file.'

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -100,13 +100,14 @@ const toggleCodeWrap = () => {
 
 onMounted(async () => {
   try {
-    // Fetch images, SVGs, and PDFs as blobs.
+    const blob = await getWorkspaceService().getRawFileBlob(
+      props.alias,
+      props.commitId,
+      props.path,
+    )
+
+    // Image-like previews use an object URL from the blob.
     if (isImage.value || isSvg.value || isPDF.value) {
-      const blob = await getWorkspaceService().getRawFileBlob(
-        props.alias,
-        props.commitId,
-        props.path,
-      )
       fileBlob.value = blob
       fileBlobUrl.value = URL.createObjectURL(blob)
 
@@ -115,12 +116,7 @@ onMounted(async () => {
         fileContent.value = await blob.text()
       }
     } else {
-      // Fetch text files through blob endpoint and decode to text.
-      const blob = await getWorkspaceService().getRawFileBlob(
-        props.alias,
-        props.commitId,
-        props.path,
-      )
+      // Text-like previews decode the fetched blob into a string.
       fileContent.value = await blob.text()
     }
   } catch (err) {

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -12,7 +12,7 @@ const LOGIN_ERROR_MESSAGES = {
 
 const normaliseErrorText = (errorText: string): string => {
   const trimmed = errorText.trim()
-  return trimmed.replace(/^['\"]|['\"]$/g, '')
+  return trimmed.replace(/^['"]|['"]$/g, '')
 }
 
 const getKnownLoginErrorMessage = (key: string): string | undefined => {

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -57,7 +57,8 @@ const mapLoginErrorMessage = (errorText: string, status: number): string => {
   }
 
   // If backend returns machine-style codes, avoid exposing raw text.
-  const looksLikeMachineCode = /^[a-z0-9_-]+$/i.test(normalisedText) || /^[A-Z][a-zA-Z0-9]+$/.test(normalisedText)
+  const looksLikeMachineCode =
+    /^[a-z0-9_-]+$/i.test(normalisedText) || /^[A-Z][a-zA-Z0-9]+$/.test(normalisedText)
   if (looksLikeMachineCode) {
     return getLoginErrorMessageByStatus(status)
   }


### PR DESCRIPTION
Fixes #124.

After trying different options, including using service workers and disabling syntax highlighting on large files, I found that neither worked, as Chrome still freezes on large files. So, the best option is to prevent showing previews or large files by setting a limit, currently approximately 500KB, by comparing the file text length for better performance. 

**Examples**

**Before the fix: file preview with syntax highlighting**
_(Opening this and scrolling down will make the browser unresponsive.)_
- https://physiome.github.io/pmrapp-frontend/workspaces/add/file/317fdad54e9aa42c0bd3e06b61ea9d9833d9364c/mapclient%20workflow/webGL/human_body_0945.json

**After the fix: no file preview**
- https://akhuoa.github.io/pmrapp-frontend/workspaces/add/file/317fdad54e9aa42c0bd3e06b61ea9d9833d9364c/mapclient%20workflow/webGL/human_body_0945.json
