### PR TITLE
Fix fetching metadata

### DIFF
--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -374,7 +374,7 @@ const loadInitialView = async () => {
   const filesWithViews = exposureInfo.value.exposure?.files?.filter(
     (file) => file.views && file.views.length > 0,
   )
-  let fileWithViews = filesWithViews?.[0]
+  let fileWithViews = filesWithViews?.find((file) => file.workspace_file_path.endsWith('.cellml'))
 
   if (props.file) {
     fileWithViews = filesWithViews?.find((file) => file.workspace_file_path === props.file)
@@ -390,9 +390,12 @@ const loadInitialView = async () => {
 
     const viewEntry = fileWithViews.views.find((v) => v.view_key === 'view')
     const licenseEntry = fileWithViews.views.find((v) => v.view_key === 'license_citation')
+    const metaEntry = fileWithViews.views.find((v) => v.view_key === 'cellml_metadata')
 
     // Show metadata onload.
-    await generateMetadata()
+    if (metaEntry) {
+      await generateMetadata()
+    }
     await checkOtherRelatedModels()
 
     if (viewEntry) {


### PR DESCRIPTION
Fixes #156.

This fixes the error on loading exposure by setting default view to `.cellml` file type instead of using the first file, and also fixes the metadata loading since some of them do not have metadata.

**Before the fix:**
https://physiome.github.io/pmrapp-frontend/exposures/3f8

**After the fix:**
https://akhuoa.github.io/pmrapp-frontend/exposures/3f8
