### PR TITLE
Open with OpenCOR for individual view

### DIFF
--- a/src/components/organisms/ExposureDetail.test.ts
+++ b/src/components/organisms/ExposureDetail.test.ts
@@ -37,6 +37,7 @@ describe('ExposureDetail', () => {
     stubs = {},
     generatedCode = '',
     mathsJSON = '[]',
+    exposureInfo = mockExposureInfo,
   }: {
     props?: Partial<{
       alias: string
@@ -46,8 +47,9 @@ describe('ExposureDetail', () => {
     stubs?: Record<string, unknown>
     generatedCode?: string
     mathsJSON?: string
+    exposureInfo?: typeof mockExposureInfo
   } = {}) => {
-    vi.spyOn(exposureStore, 'getExposureInfo').mockResolvedValue(mockExposureInfo)
+    vi.spyOn(exposureStore, 'getExposureInfo').mockResolvedValue(exposureInfo)
     vi.spyOn(exposureStore, 'getExposureSafeHTML').mockImplementation(
       async (_id, _fileId, _view, filename) => {
         if (filename === 'index.html') return '<h4>Model Status</h4>'
@@ -369,6 +371,82 @@ describe('ExposureDetail', () => {
     expect(openCorLink?.exists()).toBe(true)
     expect(openCorLink?.attributes('target')).toBe('_blank')
     expect(openCorLink?.attributes('rel')).toBe('noopener noreferrer')
+  })
+
+  describe('buildOpenCORURL', () => {
+    it('builds an openFiles OpenCOR web URL when multiple OpenCOR files are available', async () => {
+      const wrapper = await mountComponent()
+
+      const openCorLink = wrapper
+        .findAll('a')
+        .find((link) => link.text().trim() === "Open with OpenCOR's Web app")
+
+      expect(openCorLink?.exists()).toBe(true)
+
+      const href = openCorLink?.attributes('href')
+      expect(href).toBeTruthy()
+      expect(href).toContain('//opencor.ws/app/?opencor://openFiles/')
+      expect(href).toContain('baylor_hollingworth_chandler_2002_a.cellml')
+      expect(href).toContain('%7C')
+      expect(href).toContain('baylor_hollingworth_chandler_2002_f.cellml')
+    })
+
+    it('builds an openFile OpenCOR web URL for the selected .cellml route file', async () => {
+      const selectedFile = 'baylor_hollingworth_chandler_2002_c.cellml'
+      const wrapper = await mountComponent({
+        props: {
+          file: selectedFile,
+        },
+      })
+
+      const openCorLink = wrapper
+        .findAll('a')
+        .find((link) => link.text().trim() === "Open with OpenCOR's Web app")
+
+      expect(openCorLink?.exists()).toBe(true)
+
+      const href = openCorLink?.attributes('href')
+      expect(href).toBeTruthy()
+      expect(href).toContain('//opencor.ws/app/?opencor://openFile/')
+      expect(href).toContain(selectedFile)
+      expect(href).not.toContain('openFiles')
+      expect(href).not.toContain('%7C')
+    })
+
+    it('orders OpenCOR files as .cellml, .sedml, then .omex', async () => {
+      const exposureInfoWithMixedOpenCORFiles = {
+        ...mockExposureInfo,
+        files: [
+          ['archive.omex', true],
+          ['protocol.sedml', true],
+          ['model.cellml', true],
+          ['preview.png', false],
+        ] as typeof mockExposureInfo.files,
+      }
+
+      const wrapper = await mountComponent({
+        exposureInfo: exposureInfoWithMixedOpenCORFiles,
+      })
+
+      const openCorLink = wrapper
+        .findAll('a')
+        .find((link) => link.text().trim() === "Open with OpenCOR's Web app")
+
+      expect(openCorLink?.exists()).toBe(true)
+
+      const href = openCorLink?.attributes('href') || ''
+      expect(href).toContain('//opencor.ws/app/?opencor://openFiles/')
+
+      const cellmlIndex = href.indexOf('/model.cellml')
+      const sedmlIndex = href.indexOf('/protocol.sedml')
+      const omexIndex = href.indexOf('/archive.omex')
+
+      expect(cellmlIndex).toBeGreaterThan(-1)
+      expect(sedmlIndex).toBeGreaterThan(-1)
+      expect(omexIndex).toBeGreaterThan(-1)
+      expect(cellmlIndex).toBeLessThan(sedmlIndex)
+      expect(sedmlIndex).toBeLessThan(omexIndex)
+    })
   })
 
   it('renders "Navigation" section', async () => {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -710,7 +710,12 @@ onMounted(async () => {
             >
               <RouterLink
                 :to="`/exposures/${props.alias}/${entry[0]}`"
-                class="text-link inline-flex items-center gap-2 break-all"
+                class="inline-flex items-center gap-2 break-all transition-colors"
+                :class="
+                  props.file === entry[0]
+                    ? 'text-foreground cursor-default'
+                    : 'text-link'
+                "
               >
                 <span class="text-foreground">›</span>
                 {{ entry[0] }}

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -178,7 +178,14 @@ const buildOpenCORURL = (option?: string) => {
 
   const baseURL = `${exposureInfo.value.workspace.url}rawfile/${exposureInfo.value.exposure.commit_id}`
 
-  const sortedFiles = [...openCORFiles.value].sort((a, b) => {
+  const selectedCellmlFile =
+    props.file && props.file.endsWith('.cellml')
+      ? openCORFiles.value.find((entry) => entry[0] === props.file)
+      : undefined
+
+  const filesToOpen = selectedCellmlFile ? [selectedCellmlFile] : openCORFiles.value
+
+  const sortedFiles = [...filesToOpen].sort((a, b) => {
     const getOrder = (filename: string) => {
       if (filename.endsWith('.cellml')) return 1
       if (filename.endsWith('.sedml')) return 2

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -713,7 +713,7 @@ onMounted(async () => {
                 class="inline-flex items-center gap-2 break-all transition-colors"
                 :class="
                   props.file === entry[0]
-                    ? 'text-blue-600 dark:text-primary cursor-default'
+                    ? 'text-foreground dark:text-primary cursor-default'
                     : 'text-link'
                 "
               >

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -176,10 +176,15 @@ const handleDownloadCOMBINEArchive = async () => {
 }
 
 const getOpenCORFilesToOpen = (files: ExposureFileEntry[]) => {
+  let openCORFilesToOpen = files
   const selectedCellmlFile =
     props.file?.endsWith('.cellml') ? files.find((entry) => entry[0] === props.file) : undefined
 
-  return selectedCellmlFile ? [selectedCellmlFile] : files
+  if (selectedCellmlFile) {
+    openCORFilesToOpen = [selectedCellmlFile]
+  }
+
+  return openCORFilesToOpen
 }
 
 const getOrder = (filename: string) => {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -175,12 +175,14 @@ const handleDownloadCOMBINEArchive = async () => {
   }
 }
 
-const getOpenCORFilesToOpen = (files: ExposureFileEntry[]) => {
+const getOpenCORFilesToOpen = (files: ExposureFileEntry[], targetFile?: string) => {
   let openCORFilesToOpen = files
   const selectedCellmlFile =
     props.file?.endsWith('.cellml') ? files.find((entry) => entry[0] === props.file) : undefined
 
-  if (selectedCellmlFile) {
+  if (targetFile) {
+    openCORFilesToOpen = files.filter((entry) => entry[0] === targetFile)
+  } else if (selectedCellmlFile) {
     openCORFilesToOpen = [selectedCellmlFile]
   }
 
@@ -209,11 +211,11 @@ const generateOpenCORLink = (files: ExposureFileEntry[], baseURL: string, option
   return opencorLink
 }
 
-const buildOpenCORURL = (option?: string) => {
+const buildOpenCORURL = (option?: string, targetFile?: string) => {
   if (!exposureInfo.value || openCORFiles.value.length === 0) return ''
 
   const baseURL = `${exposureInfo.value.workspace.url}rawfile/${exposureInfo.value.exposure.commit_id}`
-  const filesToOpen = getOpenCORFilesToOpen(openCORFiles.value)
+  const filesToOpen = getOpenCORFilesToOpen(openCORFiles.value, targetFile)
   const sortedFiles = sortOpenCORFiles(filesToOpen)
 
   return generateOpenCORLink(sortedFiles, baseURL, option)

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -186,6 +186,17 @@ const sortOpenCORFiles = (files: ExposureFileEntry[]) => {
   return [...files].sort((a, b) => getOrder(a[0]) - getOrder(b[0]))
 }
 
+const generateOpenCORLink = (files: ExposureFileEntry[], baseURL: string, option?: string) => {
+  const fileURLs = files.map((entry) => `${baseURL}/${entry[0]}`).join('%7C')
+  const command = files.length > 1 ? 'openFiles' : 'openFile'
+  const opencorLink = `opencor://${command}/${fileURLs}`
+
+  if (option !== 'desktop') {
+    return `//opencor.ws/app/?${opencorLink}`
+  }
+  return opencorLink
+}
+
 const buildOpenCORURL = (option?: string) => {
   if (!exposureInfo.value || openCORFiles.value.length === 0) return ''
 
@@ -199,14 +210,7 @@ const buildOpenCORURL = (option?: string) => {
   const filesToOpen = selectedCellmlFile ? [selectedCellmlFile] : openCORFiles.value
   const sortedFiles = sortOpenCORFiles(filesToOpen)
 
-  const fileURLs = sortedFiles.map((entry) => `${baseURL}/${entry[0]}`).join('%7C')
-  const command = sortedFiles.length > 1 ? 'openFiles' : 'openFile'
-
-  const opencorLink = `opencor://${command}/${fileURLs}`
-  if (option !== 'desktop') {
-    return `//opencor.ws/app/?${opencorLink}`
-  }
-  return opencorLink
+  return generateOpenCORLink(sortedFiles, baseURL, option)
 }
 
 const convertFirstTextNodeToTitle = () => {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -179,7 +179,7 @@ const buildOpenCORURL = (option?: string) => {
   const baseURL = `${exposureInfo.value.workspace.url}rawfile/${exposureInfo.value.exposure.commit_id}`
 
   const selectedCellmlFile =
-    props.file && props.file.endsWith('.cellml')
+    props.file?.endsWith('.cellml')
       ? openCORFiles.value.find((entry) => entry[0] === props.file)
       : undefined
 

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -175,6 +175,13 @@ const handleDownloadCOMBINEArchive = async () => {
   }
 }
 
+const getOpenCORFilesToOpen = (files: ExposureFileEntry[]) => {
+  const selectedCellmlFile =
+    props.file?.endsWith('.cellml') ? files.find((entry) => entry[0] === props.file) : undefined
+
+  return selectedCellmlFile ? [selectedCellmlFile] : files
+}
+
 const getOrder = (filename: string) => {
   if (filename.endsWith('.cellml')) return 1
   if (filename.endsWith('.sedml')) return 2
@@ -201,13 +208,7 @@ const buildOpenCORURL = (option?: string) => {
   if (!exposureInfo.value || openCORFiles.value.length === 0) return ''
 
   const baseURL = `${exposureInfo.value.workspace.url}rawfile/${exposureInfo.value.exposure.commit_id}`
-
-  const selectedCellmlFile =
-    props.file?.endsWith('.cellml')
-      ? openCORFiles.value.find((entry) => entry[0] === props.file)
-      : undefined
-
-  const filesToOpen = selectedCellmlFile ? [selectedCellmlFile] : openCORFiles.value
+  const filesToOpen = getOpenCORFilesToOpen(openCORFiles.value)
   const sortedFiles = sortOpenCORFiles(filesToOpen)
 
   return generateOpenCORLink(sortedFiles, baseURL, option)

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -29,6 +29,8 @@ import { formatMathMLTable, initMathPolyfills, transformMathString } from '@/uti
 import { buildSearchQuery, isValidTerm } from '@/utils/search'
 import TermButton from '../atoms/TermButton.vue'
 
+type ExposureFileEntry = ExposureInfo['files'][number]
+
 const props = defineProps<{
   alias: string
   file: string
@@ -173,6 +175,17 @@ const handleDownloadCOMBINEArchive = async () => {
   }
 }
 
+const getOrder = (filename: string) => {
+  if (filename.endsWith('.cellml')) return 1
+  if (filename.endsWith('.sedml')) return 2
+  if (filename.endsWith('.omex')) return 3
+  return 4
+}
+
+const sortOpenCORFiles = (files: ExposureFileEntry[]) => {
+  return [...files].sort((a, b) => getOrder(a[0]) - getOrder(b[0]))
+}
+
 const buildOpenCORURL = (option?: string) => {
   if (!exposureInfo.value || openCORFiles.value.length === 0) return ''
 
@@ -184,16 +197,7 @@ const buildOpenCORURL = (option?: string) => {
       : undefined
 
   const filesToOpen = selectedCellmlFile ? [selectedCellmlFile] : openCORFiles.value
-
-  const sortedFiles = [...filesToOpen].sort((a, b) => {
-    const getOrder = (filename: string) => {
-      if (filename.endsWith('.cellml')) return 1
-      if (filename.endsWith('.sedml')) return 2
-      if (filename.endsWith('.omex')) return 3
-      return 4
-    }
-    return getOrder(a[0]) - getOrder(b[0])
-  })
+  const sortedFiles = sortOpenCORFiles(filesToOpen)
 
   const fileURLs = sortedFiles.map((entry) => `${baseURL}/${entry[0]}`).join('%7C')
   const command = sortedFiles.length > 1 ? 'openFiles' : 'openFile'

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -713,7 +713,7 @@ onMounted(async () => {
                 class="inline-flex items-center gap-2 break-all transition-colors"
                 :class="
                   props.file === entry[0]
-                    ? 'text-foreground cursor-default'
+                    ? 'text-blue-600 dark:text-primary cursor-default'
                     : 'text-link'
                 "
               >


### PR DESCRIPTION
Fixes #134.

### Before the fix
Clicking the "**Open with OpenCOR's web app**" button from the following page opens **all `.cellml` files**.

- https://physiome.github.io/pmrapp-frontend/exposures/210f6601f6461be8443592ff071d2592/baylor_hollingworth_chandler_2002_b.cellml

### After the fix
Clicking the "**Open with OpenCOR's web app**" button from the following page will open **only `baylor_hollingworth_chandler_2002_b.cellml`**.

- https://akhuoa.github.io/pmrapp-frontend/exposures/210f6601f6461be8443592ff071d2592/baylor_hollingworth_chandler_2002_b.cellml

### No change 
There is no change to open all CellML files on the main page.
Clicking the "**Open with OpenCOR's web app**" button from the following pages will open **all `.cellml` files**.

- https://akhuoa.github.io/pmrapp-frontend/exposures/210f6601f6461be8443592ff071d2592
- https://physiome.github.io/pmrapp-frontend/exposures/210f6601f6461be8443592ff071d2592
