### PR TITLE
Open with OpenCOR for individual files

### DIFF
--- a/src/components/icons/ExternalLinkIcon.vue
+++ b/src/components/icons/ExternalLinkIcon.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+withDefaults(defineProps<{ class?: string }>(), {
+  class: 'w-6 h-6',
+})
+</script>
+
+<template>
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    :class="$props.class"
+  >
+    <path d="M14 3h7v7"></path>
+    <path d="M10 14L21 3"></path>
+    <path d="M21 14v4a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3V6a3 3 0 0 1 3-3h4"></path>
+  </svg>
+</template>

--- a/src/components/organisms/ExposureDetail.test.ts
+++ b/src/components/organisms/ExposureDetail.test.ts
@@ -37,6 +37,7 @@ describe('ExposureDetail', () => {
     stubs = {},
     generatedCode = '',
     mathsJSON = '[]',
+    exposureInfo = mockExposureInfo,
   }: {
     props?: Partial<{
       alias: string
@@ -46,8 +47,9 @@ describe('ExposureDetail', () => {
     stubs?: Record<string, unknown>
     generatedCode?: string
     mathsJSON?: string
+    exposureInfo?: typeof mockExposureInfo
   } = {}) => {
-    vi.spyOn(exposureStore, 'getExposureInfo').mockResolvedValue(mockExposureInfo)
+    vi.spyOn(exposureStore, 'getExposureInfo').mockResolvedValue(exposureInfo)
     vi.spyOn(exposureStore, 'getExposureSafeHTML').mockImplementation(
       async (_id, _fileId, _view, filename) => {
         if (filename === 'index.html') return '<h4>Model Status</h4>'
@@ -369,6 +371,39 @@ describe('ExposureDetail', () => {
     expect(openCorLink?.exists()).toBe(true)
     expect(openCorLink?.attributes('target')).toBe('_blank')
     expect(openCorLink?.attributes('rel')).toBe('noopener noreferrer')
+  })
+
+  it('orders OpenCOR files case-insensitively as .cellml, .sedml, then .omex', async () => {
+    const exposureInfoWithMixedCaseOpenCORFiles = {
+      ...mockExposureInfo,
+      files: [
+        ['ARCHIVE.OMEX', true],
+        ['protocol.SEDML', true],
+        ['model.CELLML', true],
+        ['preview.png', false],
+      ] as typeof mockExposureInfo.files,
+    }
+
+    const wrapper = await mountComponent({
+      exposureInfo: exposureInfoWithMixedCaseOpenCORFiles,
+    })
+
+    const openCorLink = wrapper
+      .findAll('a')
+      .find((link) => link.text().includes("Open with OpenCOR's Web app"))
+
+    expect(openCorLink?.exists()).toBe(true)
+
+    const href = openCorLink?.attributes('href') || ''
+    const cellmlIndex = href.indexOf('/model.CELLML')
+    const sedmlIndex = href.indexOf('/protocol.SEDML')
+    const omexIndex = href.indexOf('/ARCHIVE.OMEX')
+
+    expect(cellmlIndex).toBeGreaterThan(-1)
+    expect(sedmlIndex).toBeGreaterThan(-1)
+    expect(omexIndex).toBeGreaterThan(-1)
+    expect(cellmlIndex).toBeLessThan(sedmlIndex)
+    expect(sedmlIndex).toBeLessThan(omexIndex)
   })
 
   it('renders "Navigation" section', async () => {

--- a/src/components/organisms/ExposureDetail.test.ts
+++ b/src/components/organisms/ExposureDetail.test.ts
@@ -373,39 +373,6 @@ describe('ExposureDetail', () => {
     expect(openCorLink?.attributes('rel')).toBe('noopener noreferrer')
   })
 
-  it('orders OpenCOR files case-insensitively as .cellml, .sedml, then .omex', async () => {
-    const exposureInfoWithMixedCaseOpenCORFiles = {
-      ...mockExposureInfo,
-      files: [
-        ['ARCHIVE.OMEX', true],
-        ['protocol.SEDML', true],
-        ['model.CELLML', true],
-        ['preview.png', false],
-      ] as typeof mockExposureInfo.files,
-    }
-
-    const wrapper = await mountComponent({
-      exposureInfo: exposureInfoWithMixedCaseOpenCORFiles,
-    })
-
-    const openCorLink = wrapper
-      .findAll('a')
-      .find((link) => link.text().includes("Open with OpenCOR's Web app"))
-
-    expect(openCorLink?.exists()).toBe(true)
-
-    const href = openCorLink?.attributes('href') || ''
-    const cellmlIndex = href.indexOf('/model.CELLML')
-    const sedmlIndex = href.indexOf('/protocol.SEDML')
-    const omexIndex = href.indexOf('/ARCHIVE.OMEX')
-
-    expect(cellmlIndex).toBeGreaterThan(-1)
-    expect(sedmlIndex).toBeGreaterThan(-1)
-    expect(omexIndex).toBeGreaterThan(-1)
-    expect(cellmlIndex).toBeLessThan(sedmlIndex)
-    expect(sedmlIndex).toBeLessThan(omexIndex)
-  })
-
   it('renders "Navigation" section', async () => {
     const wrapper = await mountComponent()
 

--- a/src/components/organisms/ExposureDetail.test.ts
+++ b/src/components/organisms/ExposureDetail.test.ts
@@ -242,13 +242,13 @@ describe('ExposureDetail', () => {
     expect(copyButton.props('text')).toBe(mockGeneratedCode)
     expect(copyButton.props('title')).toBe('Copy code')
 
-    const downloadButton = codegenView.find('button[aria-label="Download"]')
+    const downloadButton = codegenView.find('button[aria-label^="Download"]')
     expect(downloadButton.exists()).toBe(true)
 
     const srOnlyText = downloadButton.find('.sr-only')
     expect(srOnlyText.exists()).toBe(true)
     expect(downloadButton.attributes('aria-label')).toBe(srOnlyText.text())
-    expect(srOnlyText.text()).toBe('Download')
+    expect(srOnlyText.text()).toContain('Download')
   })
 
   it('calls CodeBlock.toggleWrap when clicking the wrap button in codegen view', async () => {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -9,8 +9,8 @@ import CopyButton from '@/components/atoms/CopyButton.vue'
 import LoadingBox from '@/components/atoms/LoadingBox.vue'
 import WrapButton from '@/components/atoms/WrapButton.vue'
 import ChevronDownIcon from '@/components/icons/ChevronDownIcon.vue'
-import CodeIcon from '@/components/icons/CodeIcon.vue'
 import DownloadIcon from '@/components/icons/DownloadIcon.vue'
+import ExternalLinkIcon from '@/components/icons/ExternalLinkIcon.vue'
 import FileIcon from '@/components/icons/FileIcon.vue'
 import LoadingIcon from '@/components/icons/LoadingIcon.vue'
 import ErrorBlock from '@/components/molecules/ErrorBlock.vue'
@@ -605,7 +605,7 @@ onMounted(async () => {
                   :tooltip="`Open ${entry[0]} with OpenCOR`"
                   :aria-label="`Open ${entry[0]} with OpenCOR`"
                 >
-                  <CodeIcon class="w-4 h-4" />
+                  <ExternalLinkIcon class="w-4 h-4" />
                   <span class="sr-only">Open with OpenCOR {{ entry[0] }}</span>
                 </ActionButton>
                 <ActionButton

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -31,6 +31,8 @@ import { formatMathMLTable, initMathPolyfills, transformMathString } from '@/uti
 import { buildSearchQuery, isValidTerm } from '@/utils/search'
 import TermButton from '../atoms/TermButton.vue'
 
+type ExposureFileEntry = ExposureInfo['files'][number]
+
 const props = defineProps<{
   alias: string
   file: string
@@ -174,6 +176,17 @@ const handleDownloadCOMBINEArchive = async () => {
   }
 }
 
+const getOrder = (filename: string) => {
+  if (filename.endsWith('.cellml')) return 1
+  if (filename.endsWith('.sedml')) return 2
+  if (filename.endsWith('.omex')) return 3
+  return 4
+}
+
+const sortOpenCORFiles = (files: ExposureFileEntry[]) => {
+  return [...files].sort((a, b) => getOrder(a[0]) - getOrder(b[0]))
+}
+
 const buildOpenCORURL = (option?: string, targetFile?: string) => {
   if (!exposureInfo.value || openCORFiles.value.length === 0) return ''
 
@@ -185,15 +198,7 @@ const buildOpenCORURL = (option?: string, targetFile?: string) => {
 
   if (filesToOpen.length === 0) return ''
 
-  const sortedFiles = [...filesToOpen].sort((a, b) => {
-    const getOrder = (filename: string) => {
-      if (filename.endsWith('.cellml')) return 1
-      if (filename.endsWith('.sedml')) return 2
-      if (filename.endsWith('.omex')) return 3
-      return 4
-    }
-    return getOrder(a[0]) - getOrder(b[0])
-  })
+  const sortedFiles = sortOpenCORFiles(filesToOpen)
 
   const fileURLs = sortedFiles.map((entry) => `${baseURL}/${entry[0]}`).join('%7C')
   const command = sortedFiles.length > 1 ? 'openFiles' : 'openFile'

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -562,7 +562,7 @@ onMounted(async () => {
                 aria-label="Download"
               >
                 <DownloadIcon class="w-4 h-4" />
-                <span class="sr-only">Download</span>
+                <span class="sr-only">Download {{ generatedCodeFilename }}</span>
               </ActionButton>
             </div>
           </div>
@@ -623,19 +623,19 @@ onMounted(async () => {
                   target="_blank"
                   rel="noopener noreferrer"
                   content-section="Exposure Detail"
-                  :tooltip="`Open ${entry[0]} with OpenCOR`"
-                  :aria-label="`Open ${entry[0]} with OpenCOR`"
+                  tooltip="Open with OpenCOR's Web app"
+                  aria-label="Open with OpenCOR's Web app"
                 >
                   <ExternalLinkIcon class="w-4 h-4" />
-                  <span class="sr-only">Open with OpenCOR {{ entry[0] }}</span>
+                  <span class="sr-only">Open {{ entry[0] }} with OpenCOR's Web app</span>
                 </ActionButton>
                 <ActionButton
                   @click="downloadFile(entry[0])"
                   variant="icon"
                   size="sm"
                   content-section="Exposure Detail"
-                  :tooltip="`Download ${entry[0]}`"
-                  :aria-label="`Download ${entry[0]}`"
+                  tooltip="Download"
+                  aria-label="Download"
                 >
                   <DownloadIcon class="w-4 h-4" />
                   <span class="sr-only">Download {{ entry[0] }}</span>

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -693,6 +693,7 @@ onMounted(async () => {
                 :content-section="`Exposure Detail - ${pageTitle}`"
               >
                 Open with OpenCOR's Web app
+                <ExternalLinkIcon class="w-4 h-4" />
               </ActionButton>
             </li>
             <li

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -176,6 +176,16 @@ const handleDownloadCOMBINEArchive = async () => {
   }
 }
 
+const getOpenCORFilesToOpen = (files: ExposureFileEntry[], targetFile?: string) => {
+  let openCORFilesToOpen = files
+
+  if (targetFile) {
+    openCORFilesToOpen = files.filter((entry) => entry[0] === targetFile)
+  }
+
+  return openCORFilesToOpen
+}
+
 const getOrder = (filename: string) => {
   if (filename.endsWith('.cellml')) return 1
   if (filename.endsWith('.sedml')) return 2
@@ -202,13 +212,7 @@ const buildOpenCORURL = (option?: string, targetFile?: string) => {
   if (!exposureInfo.value || openCORFiles.value.length === 0) return ''
 
   const baseURL = `${exposureInfo.value.workspace.url}rawfile/${exposureInfo.value.exposure.commit_id}`
-
-  const filesToOpen = targetFile
-    ? openCORFiles.value.filter((entry) => entry[0] === targetFile)
-    : openCORFiles.value
-
-  if (filesToOpen.length === 0) return ''
-
+  const filesToOpen = getOpenCORFilesToOpen(openCORFiles.value, targetFile)
   const sortedFiles = sortOpenCORFiles(filesToOpen)
 
   return generateOpenCORLink(sortedFiles, baseURL, option)

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -187,6 +187,17 @@ const sortOpenCORFiles = (files: ExposureFileEntry[]) => {
   return [...files].sort((a, b) => getOrder(a[0]) - getOrder(b[0]))
 }
 
+const generateOpenCORLink = (files: ExposureFileEntry[], baseURL: string, option?: string) => {
+  const fileURLs = files.map((entry) => `${baseURL}/${entry[0]}`).join('%7C')
+  const command = files.length > 1 ? 'openFiles' : 'openFile'
+  const opencorLink = `opencor://${command}/${fileURLs}`
+
+  if (option !== 'desktop') {
+    return `//opencor.ws/app/?${opencorLink}`
+  }
+  return opencorLink
+}
+
 const buildOpenCORURL = (option?: string, targetFile?: string) => {
   if (!exposureInfo.value || openCORFiles.value.length === 0) return ''
 
@@ -200,14 +211,7 @@ const buildOpenCORURL = (option?: string, targetFile?: string) => {
 
   const sortedFiles = sortOpenCORFiles(filesToOpen)
 
-  const fileURLs = sortedFiles.map((entry) => `${baseURL}/${entry[0]}`).join('%7C')
-  const command = sortedFiles.length > 1 ? 'openFiles' : 'openFile'
-
-  const opencorLink = `opencor://${command}/${fileURLs}`
-  if (option !== 'desktop') {
-    return `//opencor.ws/app/?${opencorLink}`
-  }
-  return opencorLink
+  return generateOpenCORLink(sortedFiles, baseURL, option)
 }
 
 const convertFirstTextNodeToTitle = () => {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -559,7 +559,7 @@ onMounted(async () => {
                 size="sm"
                 content-section="Exposure Detail"
                 tooltip="Download"
-                aria-label="Download"
+                :aria-label="`Download ${generatedCodeFilename}`"
               >
                 <DownloadIcon class="w-4 h-4" />
                 <span class="sr-only">Download {{ generatedCodeFilename }}</span>
@@ -624,7 +624,7 @@ onMounted(async () => {
                   rel="noopener noreferrer"
                   content-section="Exposure Detail"
                   tooltip="Open with OpenCOR's Web app"
-                  aria-label="Open with OpenCOR's Web app"
+                  :aria-label="`Open ${entry[0]} with OpenCOR's Web app`"
                 >
                   <ExternalLinkIcon class="w-4 h-4" />
                   <span class="sr-only">Open {{ entry[0] }} with OpenCOR's Web app</span>
@@ -635,7 +635,7 @@ onMounted(async () => {
                   size="sm"
                   content-section="Exposure Detail"
                   tooltip="Download"
-                  aria-label="Download"
+                  :aria-label="`Download ${entry[0]}`"
                 >
                   <DownloadIcon class="w-4 h-4" />
                   <span class="sr-only">Download {{ entry[0] }}</span>

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -556,6 +556,7 @@ onMounted(async () => {
               <ActionButton
                 @click="downloadCode"
                 variant="icon"
+                size="sm"
                 content-section="Exposure Detail"
                 tooltip="Download"
                 aria-label="Download"
@@ -617,6 +618,7 @@ onMounted(async () => {
                 <ActionButton
                   v-if="isOpenCORFile(entry[0])"
                   variant="icon"
+                  size="sm"
                   :href="buildOpenCORURL(undefined, entry[0])"
                   target="_blank"
                   rel="noopener noreferrer"
@@ -630,6 +632,7 @@ onMounted(async () => {
                 <ActionButton
                   @click="downloadFile(entry[0])"
                   variant="icon"
+                  size="sm"
                   content-section="Exposure Detail"
                   :tooltip="`Download ${entry[0]}`"
                   :aria-label="`Download ${entry[0]}`"

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -9,6 +9,7 @@ import CopyButton from '@/components/atoms/CopyButton.vue'
 import LoadingBox from '@/components/atoms/LoadingBox.vue'
 import WrapButton from '@/components/atoms/WrapButton.vue'
 import ChevronDownIcon from '@/components/icons/ChevronDownIcon.vue'
+import CodeIcon from '@/components/icons/CodeIcon.vue'
 import DownloadIcon from '@/components/icons/DownloadIcon.vue'
 import FileIcon from '@/components/icons/FileIcon.vue'
 import LoadingIcon from '@/components/icons/LoadingIcon.vue'
@@ -123,10 +124,13 @@ const openCORFiles = computed(() => {
   if (!exposureInfo.value) return []
 
   return exposureInfo.value.files.filter((entry) => {
-    const filename = entry[0]
-    return filename.endsWith('.omex') || filename.endsWith('.cellml') || filename.endsWith('.sedml')
+    return isOpenCORFile(entry[0])
   })
 })
+
+const isOpenCORFile = (filename: string) => {
+  return filename.endsWith('.omex') || filename.endsWith('.cellml') || filename.endsWith('.sedml')
+}
 
 const navigationFiles = computed(() => {
   if (!exposureInfo.value) return []
@@ -173,12 +177,18 @@ const handleDownloadCOMBINEArchive = async () => {
   }
 }
 
-const buildOpenCORURL = (option?: string) => {
+const buildOpenCORURL = (option?: string, targetFile?: string) => {
   if (!exposureInfo.value || openCORFiles.value.length === 0) return ''
 
   const baseURL = `${exposureInfo.value.workspace.url}rawfile/${exposureInfo.value.exposure.commit_id}`
 
-  const sortedFiles = [...openCORFiles.value].sort((a, b) => {
+  const filesToOpen = targetFile
+    ? openCORFiles.value.filter((entry) => entry[0] === targetFile)
+    : openCORFiles.value
+
+  if (filesToOpen.length === 0) return ''
+
+  const sortedFiles = [...filesToOpen].sort((a, b) => {
     const getOrder = (filename: string) => {
       if (filename.endsWith('.cellml')) return 1
       if (filename.endsWith('.sedml')) return 2
@@ -588,6 +598,19 @@ onMounted(async () => {
                 </RouterLink>
               </div>
               <div class="flex items-center gap-2 ml-4 flex-shrink-0">
+                <ActionButton
+                  v-if="isOpenCORFile(entry[0])"
+                  variant="icon"
+                  :href="buildOpenCORURL(undefined, entry[0])"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  content-section="Exposure Detail"
+                  :tooltip="`Open ${entry[0]} with OpenCOR`"
+                  :aria-label="`Open ${entry[0]} with OpenCOR`"
+                >
+                  <CodeIcon class="w-4 h-4" />
+                  <span class="sr-only">Open with OpenCOR {{ entry[0] }}</span>
+                </ActionButton>
                 <ActionButton
                   @click="downloadFile(entry[0])"
                   variant="icon"

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -24,7 +24,7 @@ import type { ExposureInfo, Metadata, ViewEntry } from '@/types/exposure'
 import { formatCitation, formatCitationAuthor } from '@/utils/citation'
 import { downloadFileFromContent, downloadWorkspaceFile } from '@/utils/download'
 import { getExposureIdFromResourcePath } from '@/utils/exposure'
-import { isOpenCORFile } from '@/utils/file'
+import { getFileExtension, isOpenCORFile } from '@/utils/file'
 import { formatFileCount } from '@/utils/format'
 import { formatLicenseUrl } from '@/utils/license'
 import { formatMathMLTable, initMathPolyfills, transformMathString } from '@/utils/mathTransformer'
@@ -187,9 +187,11 @@ const getOpenCORFilesToOpen = (files: ExposureFileEntry[], targetFile?: string) 
 }
 
 const getOrder = (filename: string) => {
-  if (filename.endsWith('.cellml')) return 1
-  if (filename.endsWith('.sedml')) return 2
-  if (filename.endsWith('.omex')) return 3
+  const extension = getFileExtension(filename)
+
+  if (extension === 'cellml') return 1
+  if (extension === 'sedml') return 2
+  if (extension === 'omex') return 3
   return 4
 }
 

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -178,8 +178,9 @@ const handleDownloadCOMBINEArchive = async () => {
 
 const getOpenCORFilesToOpen = (files: ExposureFileEntry[], targetFile?: string) => {
   let openCORFilesToOpen = files
-  const selectedCellmlFile =
-    props.file?.endsWith('.cellml') ? files.find((entry) => entry[0] === props.file) : undefined
+  const selectedCellmlFile = props.file?.endsWith('.cellml')
+    ? files.find((entry) => entry[0] === props.file)
+    : undefined
 
   if (targetFile) {
     openCORFilesToOpen = files.filter((entry) => entry[0] === targetFile)

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -24,6 +24,7 @@ import type { ExposureInfo, Metadata, ViewEntry } from '@/types/exposure'
 import { formatCitation, formatCitationAuthor } from '@/utils/citation'
 import { downloadFileFromContent, downloadWorkspaceFile } from '@/utils/download'
 import { getExposureIdFromResourcePath } from '@/utils/exposure'
+import { isOpenCORFile } from '@/utils/file'
 import { formatFileCount } from '@/utils/format'
 import { formatLicenseUrl } from '@/utils/license'
 import { formatMathMLTable, initMathPolyfills, transformMathString } from '@/utils/mathTransformer'
@@ -127,10 +128,6 @@ const openCORFiles = computed(() => {
     return isOpenCORFile(entry[0])
   })
 })
-
-const isOpenCORFile = (filename: string) => {
-  return filename.endsWith('.omex') || filename.endsWith('.cellml') || filename.endsWith('.sedml')
-}
 
 const navigationFiles = computed(() => {
   if (!exposureInfo.value) return []

--- a/src/components/organisms/WorkspaceDetail.vue
+++ b/src/components/organisms/WorkspaceDetail.vue
@@ -6,6 +6,7 @@ import ActionButton from '@/components/atoms/ActionButton.vue'
 import BackButton from '@/components/atoms/BackButton.vue'
 import LoadingBox from '@/components/atoms/LoadingBox.vue'
 import DownloadIcon from '@/components/icons/DownloadIcon.vue'
+import ExternalLinkIcon from '@/components/icons/ExternalLinkIcon.vue'
 import FileIcon from '@/components/icons/FileIcon.vue'
 import FolderIcon from '@/components/icons/FolderIcon.vue'
 import LoadingIcon from '@/components/icons/LoadingIcon.vue'
@@ -16,6 +17,7 @@ import { useWorkspaceStore } from '@/stores/workspace'
 import type { ErrorInfo } from '@/types/error'
 import type { WorkspaceInfo } from '@/types/workspace'
 import { downloadWorkspaceFile } from '@/utils/download'
+import { isOpenCORFile } from '@/utils/file'
 import { formatFileCount } from '@/utils/format'
 
 const props = defineProps<{
@@ -108,6 +110,16 @@ const downloadFile = async (filename: string) => {
   const fullFilename = (props.path ? `${props.path}/` : '') + filename
   if (!commitId) return
   await downloadWorkspaceFile(alias, commitId, fullFilename)
+}
+
+const buildOpenCORURL = (filename: string) => {
+  if (!workspaceInfo.value) return ''
+
+  const fullFilename = (props.path ? `${props.path}/` : '') + filename
+  const baseURL = `${workspaceInfo.value.workspace.url}rawfile/${workspaceInfo.value.commit.commit_id}`
+  const opencorLink = `opencor://openFile/${baseURL}/${fullFilename}`
+
+  return `//opencor.ws/app/?${opencorLink}`
 }
 
 const handleDownloadWorkspaceArchive = async (format: 'zip' | 'tgz') => {
@@ -268,17 +280,32 @@ watch(() => [props.alias, props.commitId, props.path], loadWorkspaceInfo)
                 {{ entry.name }}
               </RouterLink>
             </div>
-            <ActionButton
-              v-if="entry.kind !== 'tree'"
-              variant="icon"
-              content-section="Workspace Detail"
-              @click="downloadFile(entry.name)"
-              :tooltip="`Download ${entry.name}`"
-              :aria-label="`Download ${entry.name}`"
-            >
-              <DownloadIcon class="w-4 h-4" />
-              <span class="sr-only">Download {{ entry.name }}</span>
-            </ActionButton>
+            <div class="flex items-center gap-2 ml-4 flex-shrink-0">
+              <ActionButton
+                v-if="entry.kind !== 'tree' && isOpenCORFile(entry.name)"
+                variant="icon"
+                :href="buildOpenCORURL(entry.name)"
+                target="_blank"
+                rel="noopener noreferrer"
+                content-section="Workspace Detail"
+                :tooltip="`Open ${entry.name} with OpenCOR`"
+                :aria-label="`Open ${entry.name} with OpenCOR`"
+              >
+                <ExternalLinkIcon class="w-4 h-4" />
+                <span class="sr-only">Open with OpenCOR {{ entry.name }}</span>
+              </ActionButton>
+              <ActionButton
+                v-if="entry.kind !== 'tree'"
+                variant="icon"
+                content-section="Workspace Detail"
+                @click="downloadFile(entry.name)"
+                :tooltip="`Download ${entry.name}`"
+                :aria-label="`Download ${entry.name}`"
+              >
+                <DownloadIcon class="w-4 h-4" />
+                <span class="sr-only">Download {{ entry.name }}</span>
+              </ActionButton>
+            </div>
           </div>
         </li>
       </ul>

--- a/src/components/organisms/WorkspaceDetail.vue
+++ b/src/components/organisms/WorkspaceDetail.vue
@@ -284,6 +284,7 @@ watch(() => [props.alias, props.commitId, props.path], loadWorkspaceInfo)
               <ActionButton
                 v-if="entry.kind !== 'tree' && isOpenCORFile(entry.name)"
                 variant="icon"
+                size="sm"
                 :href="buildOpenCORURL(entry.name)"
                 target="_blank"
                 rel="noopener noreferrer"
@@ -297,6 +298,7 @@ watch(() => [props.alias, props.commitId, props.path], loadWorkspaceInfo)
               <ActionButton
                 v-if="entry.kind !== 'tree'"
                 variant="icon"
+                size="sm"
                 content-section="Workspace Detail"
                 @click="downloadFile(entry.name)"
                 :tooltip="`Download ${entry.name}`"

--- a/src/components/organisms/WorkspaceDetail.vue
+++ b/src/components/organisms/WorkspaceDetail.vue
@@ -289,11 +289,11 @@ watch(() => [props.alias, props.commitId, props.path], loadWorkspaceInfo)
                 target="_blank"
                 rel="noopener noreferrer"
                 content-section="Workspace Detail"
-                :tooltip="`Open ${entry.name} with OpenCOR`"
-                :aria-label="`Open ${entry.name} with OpenCOR`"
+                tooltip="Open with OpenCOR's Web app"
+                aria-label="Open with OpenCOR's Web app"
               >
                 <ExternalLinkIcon class="w-4 h-4" />
-                <span class="sr-only">Open with OpenCOR {{ entry.name }}</span>
+                <span class="sr-only">Open {{ entry.name }} with OpenCOR's Web app</span>
               </ActionButton>
               <ActionButton
                 v-if="entry.kind !== 'tree'"
@@ -301,8 +301,8 @@ watch(() => [props.alias, props.commitId, props.path], loadWorkspaceInfo)
                 size="sm"
                 content-section="Workspace Detail"
                 @click="downloadFile(entry.name)"
-                :tooltip="`Download ${entry.name}`"
-                :aria-label="`Download ${entry.name}`"
+                tooltip="Download"
+                aria-label="Download"
               >
                 <DownloadIcon class="w-4 h-4" />
                 <span class="sr-only">Download {{ entry.name }}</span>

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -15,7 +15,14 @@ import PageHeader from '@/components/molecules/PageHeader.vue'
 import { useBackNavigation } from '@/composables/useBackNavigation'
 import { getWorkspaceService } from '@/services'
 import { downloadFileFromBlob } from '@/utils/download'
-import { isCodeFile, isImageFile, isMarkdownFile, isOpenCORFile, isPdfFile, isSvgFile } from '@/utils/file'
+import {
+  isCodeFile,
+  isImageFile,
+  isMarkdownFile,
+  isOpenCORFile,
+  isPdfFile,
+  isSvgFile,
+} from '@/utils/file'
 import { renderMarkdown } from '@/utils/markdown'
 import ActionButton from '../atoms/ActionButton.vue'
 
@@ -114,7 +121,11 @@ const loadWorkspaceURLForOpenCOR = async () => {
 
   isOpenCORURLLoading.value = true
   try {
-    const workspaceInfo = await getWorkspaceService().getWorkspaceInfo(props.alias, props.commitId, '')
+    const workspaceInfo = await getWorkspaceService().getWorkspaceInfo(
+      props.alias,
+      props.commitId,
+      '',
+    )
     workspaceURL.value = workspaceInfo.workspace.url
   } catch (workspaceErr) {
     console.error('Error loading workspace URL for OpenCOR link:', workspaceErr)

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -33,6 +33,7 @@ const fileBlob = ref<Blob>(new Blob())
 const fileBlobUrl = ref<string>('')
 const fileSizeBytes = ref(0)
 const workspaceURL = ref<string>('')
+const isOpenCORURLLoading = ref(false)
 const error = ref<string | null>(null)
 const isLoading = ref(true)
 const showCode = ref(false)
@@ -63,6 +64,9 @@ const isSvg = computed(() => isSvgFile(props.path))
 const isMarkdown = computed(() => isMarkdownFile(props.path))
 const isCode = computed(() => isCodeFile(props.path))
 const isOpenCOR = computed(() => isOpenCORFile(props.path))
+const canShowOpenCORButton = computed(
+  () => isOpenCOR.value && !isOpenCORURLLoading.value && !!openCORFileURL.value,
+)
 
 const openCORFileURL = computed(() => {
   if (!workspaceURL.value) return ''
@@ -105,16 +109,25 @@ const toggleCodeWrap = () => {
   codeBlockRef.value?.toggleWrap()
 }
 
-onMounted(async () => {
-  try {
-    // TODO: to refactor
-    try {
-      const workspaceInfo = await getWorkspaceService().getWorkspaceInfo(props.alias, props.commitId, '')
-      workspaceURL.value = workspaceInfo.workspace.url
-    } catch (workspaceErr) {
-      console.error('Error loading workspace URL for OpenCOR link:', workspaceErr)
-    }
+const loadWorkspaceURLForOpenCOR = async () => {
+  if (!isOpenCOR.value) return
 
+  isOpenCORURLLoading.value = true
+  try {
+    const workspaceInfo = await getWorkspaceService().getWorkspaceInfo(props.alias, props.commitId, '')
+    workspaceURL.value = workspaceInfo.workspace.url
+  } catch (workspaceErr) {
+    console.error('Error loading workspace URL for OpenCOR link:', workspaceErr)
+  } finally {
+    isOpenCORURLLoading.value = false
+  }
+}
+
+onMounted(async () => {
+  // OpenCOR link data loads separately so file preview is not blocked.
+  void loadWorkspaceURLForOpenCOR()
+
+  try {
     const blob = await getWorkspaceService().getRawFileBlob(props.alias, props.commitId, props.path)
     fileBlob.value = blob
     fileSizeBytes.value = blob.size
@@ -171,7 +184,7 @@ onBeforeUnmount(() => {
       <div class="flex items-center justify-end px-4 py-3 border-b border-gray-200 dark:border-gray-700">
         <div class="flex items-center gap-2">
           <ActionButton
-            v-if="isOpenCOR && openCORFileURL"
+            v-if="canShowOpenCORButton"
             variant="secondary"
             size="sm"
             content-section="Workspace File Detail"

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -198,15 +198,17 @@ onBeforeUnmount(() => {
         <div class="flex items-center gap-2">
           <ActionButton
             v-if="canShowOpenCORButton"
-            variant="secondary"
+            variant="icon"
             size="sm"
             content-section="Workspace File Detail"
             :href="openCORFileURL"
             target="_blank"
             rel="noopener noreferrer"
+            tooltip="Open with OpenCOR's Web app"
+            aria-label="Open with OpenCOR's Web app"
           >
-            <span>Open with OpenCOR's Web app</span>
-            <ExternalLinkIcon class="w-4 h-4" />
+          <ExternalLinkIcon class="w-4 h-4" />
+          <span class="sr-only">Open with OpenCOR's Web app</span>
           </ActionButton>
           <button
             v-if="isSvg || isMarkdown"
@@ -230,10 +232,11 @@ onBeforeUnmount(() => {
           />
           <ActionButton
             variant="icon"
+            size="sm"
             content-section="Workspace File Detail"
             @click="downloadFile"
             tooltip="Download"
-            :aria-label="'Download'"
+            aria-label="Download"
           >
             <DownloadIcon class="w-4 h-4" />
             <span class="sr-only">Download</span>

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -21,7 +21,6 @@ import ActionButton from '../atoms/ActionButton.vue'
 
 // Files with size above this threshold are not rendered in the preview to prevent browser freeze.
 const MAX_PREVIEW_FILE_SIZE_BYTES = 500 * 1024 // ~500 KB
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
 
 const props = defineProps<{
   alias: string
@@ -33,6 +32,7 @@ const fileContent = ref<string>('')
 const fileBlob = ref<Blob>(new Blob())
 const fileBlobUrl = ref<string>('')
 const fileSizeBytes = ref(0)
+const workspaceURL = ref<string>('')
 const error = ref<string | null>(null)
 const isLoading = ref(true)
 const showCode = ref(false)
@@ -65,8 +65,9 @@ const isCode = computed(() => isCodeFile(props.path))
 const isOpenCOR = computed(() => isOpenCORFile(props.path))
 
 const openCORFileURL = computed(() => {
-  // TODO: to fix API_BASE_URL
-  const rawFileURL = `${API_BASE_URL}/api/workspace/${props.alias}/rawfile/${props.commitId}/${props.path}`
+  if (!workspaceURL.value) return ''
+
+  const rawFileURL = `${workspaceURL.value}rawfile/${props.commitId}/${props.path}`
   const opencorLink = `opencor://openFile/${rawFileURL}`
   return `//opencor.ws/app/?${opencorLink}`
 })
@@ -106,6 +107,14 @@ const toggleCodeWrap = () => {
 
 onMounted(async () => {
   try {
+    // TODO: to refactor
+    try {
+      const workspaceInfo = await getWorkspaceService().getWorkspaceInfo(props.alias, props.commitId, '')
+      workspaceURL.value = workspaceInfo.workspace.url
+    } catch (workspaceErr) {
+      console.error('Error loading workspace URL for OpenCOR link:', workspaceErr)
+    }
+
     const blob = await getWorkspaceService().getRawFileBlob(props.alias, props.commitId, props.path)
     fileBlob.value = blob
     fileSizeBytes.value = blob.size
@@ -162,7 +171,7 @@ onBeforeUnmount(() => {
       <div class="flex items-center justify-end px-4 py-3 border-b border-gray-200 dark:border-gray-700">
         <div class="flex items-center gap-2">
           <ActionButton
-            v-if="isOpenCOR"
+            v-if="isOpenCOR && openCORFileURL"
             variant="secondary"
             size="sm"
             content-section="Workspace File Detail"

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -123,11 +123,7 @@ const loadWorkspaceURLForOpenCOR = async () => {
 
   isOpenCORURLLoading.value = true
   try {
-    const workspaceInfo = await workspaceStore.getWorkspaceInfo(
-      props.alias,
-      props.commitId,
-      '',
-    )
+    const workspaceInfo = await workspaceStore.getWorkspaceInfo(props.alias, props.commitId, '')
     workspaceURL.value = workspaceInfo.workspace.url
   } catch (workspaceErr) {
     console.error('Error loading workspace URL for OpenCOR link:', workspaceErr)

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -8,18 +8,20 @@ import LoadingBox from '@/components/atoms/LoadingBox.vue'
 import WrapButton from '@/components/atoms/WrapButton.vue'
 import CodeIcon from '@/components/icons/CodeIcon.vue'
 import DownloadIcon from '@/components/icons/DownloadIcon.vue'
+import ExternalLinkIcon from '@/components/icons/ExternalLinkIcon.vue'
 import PreviewIcon from '@/components/icons/PreviewIcon.vue'
 import ErrorBlock from '@/components/molecules/ErrorBlock.vue'
 import PageHeader from '@/components/molecules/PageHeader.vue'
 import { useBackNavigation } from '@/composables/useBackNavigation'
 import { getWorkspaceService } from '@/services'
 import { downloadFileFromBlob } from '@/utils/download'
-import { isCodeFile, isImageFile, isMarkdownFile, isPdfFile, isSvgFile } from '@/utils/file'
+import { isCodeFile, isImageFile, isMarkdownFile, isOpenCORFile, isPdfFile, isSvgFile } from '@/utils/file'
 import { renderMarkdown } from '@/utils/markdown'
 import ActionButton from '../atoms/ActionButton.vue'
 
 // Files with size above this threshold are not rendered in the preview to prevent browser freeze.
 const MAX_PREVIEW_FILE_SIZE_BYTES = 500 * 1024 // ~500 KB
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
 
 const props = defineProps<{
   alias: string
@@ -60,6 +62,14 @@ const isPDF = computed(() => isPdfFile(props.path))
 const isSvg = computed(() => isSvgFile(props.path))
 const isMarkdown = computed(() => isMarkdownFile(props.path))
 const isCode = computed(() => isCodeFile(props.path))
+const isOpenCOR = computed(() => isOpenCORFile(props.path))
+
+const openCORFileURL = computed(() => {
+  // TODO: to fix API_BASE_URL
+  const rawFileURL = `${API_BASE_URL}/api/workspace/${props.alias}/rawfile/${props.commitId}/${props.path}`
+  const opencorLink = `opencor://openFile/${rawFileURL}`
+  return `//opencor.ws/app/?${opencorLink}`
+})
 
 const shouldShowAsText = computed(() => {
   return isCode.value || (isSvg.value && showCode.value) || (isMarkdown.value && showCode.value)
@@ -151,6 +161,18 @@ onBeforeUnmount(() => {
     <div class="box p-0! overflow-hidden">
       <div class="flex items-center justify-end px-4 py-3 border-b border-gray-200 dark:border-gray-700">
         <div class="flex items-center gap-2">
+          <ActionButton
+            v-if="isOpenCOR"
+            variant="secondary"
+            size="sm"
+            content-section="Workspace File Detail"
+            :href="openCORFileURL"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span>Open with OpenCOR's Web app</span>
+            <ExternalLinkIcon class="w-4 h-4" />
+          </ActionButton>
           <button
             v-if="isSvg || isMarkdown"
             @click="toggleCodeView"

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -14,6 +14,7 @@ import ErrorBlock from '@/components/molecules/ErrorBlock.vue'
 import PageHeader from '@/components/molecules/PageHeader.vue'
 import { useBackNavigation } from '@/composables/useBackNavigation'
 import { getWorkspaceService } from '@/services'
+import { useWorkspaceStore } from '@/stores/workspace'
 import { downloadFileFromBlob } from '@/utils/download'
 import {
   isCodeFile,
@@ -64,6 +65,7 @@ const backPath = computed(() => {
 })
 
 const { goBack } = useBackNavigation(backPath.value)
+const workspaceStore = useWorkspaceStore()
 
 const isImage = computed(() => isImageFile(props.path))
 const isPDF = computed(() => isPdfFile(props.path))
@@ -121,7 +123,7 @@ const loadWorkspaceURLForOpenCOR = async () => {
 
   isOpenCORURLLoading.value = true
   try {
-    const workspaceInfo = await getWorkspaceService().getWorkspaceInfo(
+    const workspaceInfo = await workspaceStore.getWorkspaceInfo(
       props.alias,
       props.commitId,
       '',

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -196,20 +196,6 @@ onBeforeUnmount(() => {
     <div class="box p-0! overflow-hidden">
       <div class="flex items-center justify-end px-4 py-3 border-b border-gray-200 dark:border-gray-700">
         <div class="flex items-center gap-2">
-          <ActionButton
-            v-if="canShowOpenCORButton"
-            variant="icon"
-            size="sm"
-            content-section="Workspace File Detail"
-            :href="openCORFileURL"
-            target="_blank"
-            rel="noopener noreferrer"
-            tooltip="Open with OpenCOR's Web app"
-            aria-label="Open with OpenCOR's Web app"
-          >
-          <ExternalLinkIcon class="w-4 h-4" />
-          <span class="sr-only">Open with OpenCOR's Web app</span>
-          </ActionButton>
           <button
             v-if="isSvg || isMarkdown"
             @click="toggleCodeView"
@@ -230,6 +216,20 @@ onBeforeUnmount(() => {
             :text="fileContent"
             title="Copy code"
           />
+          <ActionButton
+            v-if="canShowOpenCORButton"
+            variant="icon"
+            size="sm"
+            content-section="Workspace File Detail"
+            :href="openCORFileURL"
+            target="_blank"
+            rel="noopener noreferrer"
+            tooltip="Open with OpenCOR's Web app"
+            aria-label="Open with OpenCOR's Web app"
+          >
+            <ExternalLinkIcon class="w-4 h-4" />
+            <span class="sr-only">Open with OpenCOR's Web app</span>
+          </ActionButton>
           <ActionButton
             variant="icon"
             size="sm"

--- a/src/utils/file.test.ts
+++ b/src/utils/file.test.ts
@@ -5,6 +5,7 @@ import {
   isCodeFile,
   isImageFile,
   isMarkdownFile,
+  isOpenCORFile,
   isPdfFile,
   isSvgFile,
 } from '@/utils/file'
@@ -57,6 +58,26 @@ describe('isPdfFile', () => {
 
   it('returns false for non-pdf files', () => {
     expect(isPdfFile('doc.txt')).toBe(false)
+  })
+})
+
+describe('isOpenCORFile', () => {
+  it('returns true for OpenCOR-compatible extensions', () => {
+    for (const ext of ['cellml', 'sedml', 'omex']) {
+      expect(isOpenCORFile(`file.${ext}`)).toBe(true)
+    }
+  })
+
+  it('returns true for OpenCOR-compatible extensions regardless of case', () => {
+    expect(isOpenCORFile('model.CELLML')).toBe(true)
+    expect(isOpenCORFile('simulation.SEDML')).toBe(true)
+    expect(isOpenCORFile('archive.OMEX')).toBe(true)
+  })
+
+  it('returns false for non-OpenCOR files', () => {
+    expect(isOpenCORFile('file.txt')).toBe(false)
+    expect(isOpenCORFile('image.png')).toBe(false)
+    expect(isOpenCORFile('README')).toBe(false)
   })
 })
 

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -42,7 +42,7 @@ export const isPdfFile = (filename: string): boolean => {
 }
 
 /**
- * Check if file is compatible to open with OpenCOR.
+ * Check if a file can be opened with OpenCOR.
  */
 export const isOpenCORFile = (filename: string): boolean => {
   const extension = getFileExtension(filename)

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -42,6 +42,14 @@ export const isPdfFile = (filename: string): boolean => {
 }
 
 /**
+ * Check if file is compatible to open with OpenCOR.
+ */
+export const isOpenCORFile = (filename: string): boolean => {
+  const extension = getFileExtension(filename)
+  return ['omex', 'cellml', 'sedml'].includes(extension)
+}
+
+/**
  * Check if file is a markdown file.
  */
 export const isMarkdownFile = (filename: string): boolean => {


### PR DESCRIPTION
Fixes #133.

Individual files that can be opened with OpenCOR (`.cellml`, `.sedml`, and `.omex`) now have Open with OpenCOR buttons. The button in the file browser is beside the download button and displays an external link icon. It will display a tooltip with the file name to open with OpenCOR when the mouse hovers over it.

### Examples
Exposure files browser: 
- https://akhuoa.github.io/pmrapp-frontend/exposures/210f6601f6461be8443592ff071d2592

Workspace files browser: 
- https://akhuoa.github.io/pmrapp-frontend/workspaces/baylor_hollingworth_chandler_2002

Individual file view: 
- https://akhuoa.github.io/pmrapp-frontend/workspaces/baylor_hollingworth_chandler_2002/file/d3cc9340e6435cf492ae8a132a5272fb1d4b612f/baylor_hollingworth_chandler_2002_a.cellml
