### PR TITLE
Query search

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -48,6 +48,11 @@
   .scrollbar-thin {
     scrollbar-width: thin;
   }
+
+  .text-highlight,
+  mark {
+    @apply bg-amber-200 dark:bg-amber-400 text-accent;
+  }
 }
 
 :root {

--- a/src/assets/text-highlight.css
+++ b/src/assets/text-highlight.css
@@ -1,6 +1,7 @@
 @reference "tailwindcss";
 @reference "./main.css";
 
-.text-highlight {
+.text-highlight,
+:deep(mark) {
   @apply bg-amber-200 dark:bg-amber-400 text-accent;
 }

--- a/src/assets/text-highlight.css
+++ b/src/assets/text-highlight.css
@@ -1,7 +1,0 @@
-@reference "tailwindcss";
-@reference "./main.css";
-
-.text-highlight,
-:deep(mark) {
-  @apply bg-amber-200 dark:bg-amber-400 text-accent;
-}

--- a/src/components/atoms/Keycap.vue
+++ b/src/components/atoms/Keycap.vue
@@ -1,0 +1,13 @@
+<template>
+  <kbd class="keycap">
+    <slot />
+  </kbd>
+</template>
+
+<style scoped>
+@reference "tailwindcss";
+
+.keycap {
+  @apply inline-flex items-center px-1.5 py-0.5 text-sm font-semibold rounded border border-gray-300 dark:border-gray-600 bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-200;
+}
+</style>

--- a/src/components/atoms/SearchEnterHint.vue
+++ b/src/components/atoms/SearchEnterHint.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import Keycap from '@/components/atoms/Keycap.vue'
+
+withDefaults(defineProps<{ query: string; suffix?: string }>(), { suffix: '' })
+</script>
+
+<template>
+  Press <Keycap>Enter</Keycap> to search for
+  <span class="text-gray-700 dark:text-gray-200 font-semibold">"{{ query }}"</span>
+  anywhere in the repository{{ suffix }}.
+</template>

--- a/src/components/atoms/SearchField.vue
+++ b/src/components/atoms/SearchField.vue
@@ -46,10 +46,6 @@ const handleSearchClick = () => {
 
 const handleKeyup = (event: KeyboardEvent) => {
   emit('keyup', event)
-  // TODO: Emit 'search' event when Enter is pressed once API is available.
-  // if (event.key === 'Enter') {
-  //   emit('search')
-  // }
 }
 
 const handleFocus = (event: FocusEvent) => {

--- a/src/components/atoms/SearchField.vue
+++ b/src/components/atoms/SearchField.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import SearchIcon from '../icons/SearchIcon.vue'
 import CloseButton from './CloseButton.vue'
 
 interface Props {
@@ -35,6 +36,10 @@ const handleClear = () => {
   inputRef.value?.focus()
 }
 
+const handleSearchClick = () => {
+  emit('search')
+}
+
 const handleKeyup = (event: KeyboardEvent) => {
   emit('keyup', event)
   // TODO: Emit 'search' event when Enter is pressed once API is available.
@@ -58,7 +63,7 @@ defineExpose({
 </script>
 
 <template>
-  <div class="relative flex items-center">
+  <div class="relative flex items-center overflow-hidden">
     <input
       ref="inputRef"
       type="text"
@@ -73,21 +78,30 @@ defineExpose({
     />
     <div
       v-if="modelValue"
-      class="absolute right-2 flex items-center hover:bg-gray-200 dark:hover:bg-gray-700 rounded-full cursor-pointer p-1"
+      class="absolute right-12 flex items-center hover:bg-gray-200 dark:hover:bg-gray-700 rounded-full cursor-pointer p-1"
     >
       <CloseButton
         @click="handleClear"
         aria-label="Clear search"
       />
     </div>
+    <button
+      type="button"
+      class="absolute inset-y-0 right-0 flex items-center justify-center px-3 border-l border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-default disabled:hover:bg-transparent"
+      aria-label="Search"
+      :disabled="!modelValue"
+      @click="handleSearchClick"
+    >
+      <SearchIcon class="w-4 h-4" />
+    </button>
   </div>
 </template>
 
 <style scoped>
 @import '@/assets/input.css';
 
-/* Space for clear button */
+/* Space for clear and search buttons */
 input {
-  padding-right: 2.5rem !important;
+  padding-right: 5.5rem !important;
 }
 </style>

--- a/src/components/atoms/SearchField.vue
+++ b/src/components/atoms/SearchField.vue
@@ -8,13 +8,17 @@ interface Props {
   placeholder?: string
   ariaLabel?: string
   inputClass?: string
+  withSearchButton?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   placeholder: 'Search...',
   ariaLabel: 'Search',
   inputClass: '',
+  withSearchButton: false,
 })
+
+const inputPaddingClass = props.withSearchButton ? 'pr-[5.5rem]!' : 'pr-[2.5rem]!'
 
 const emit = defineEmits<{
   'update:modelValue': [value: string]
@@ -63,14 +67,14 @@ defineExpose({
 </script>
 
 <template>
-  <div class="relative flex items-center overflow-hidden">
+  <div class="relative flex items-center" :class="{'overflow-hidden': props.withSearchButton}">
     <input
       ref="inputRef"
       type="text"
       :value="modelValue"
       :placeholder="placeholder"
       :aria-label="ariaLabel"
-      :class="inputClass"
+      :class="[inputPaddingClass, inputClass]"
       @input="handleInput"
       @keyup="handleKeyup"
       @focus="handleFocus"
@@ -78,7 +82,8 @@ defineExpose({
     />
     <div
       v-if="modelValue"
-      class="absolute right-12 flex items-center hover:bg-gray-200 dark:hover:bg-gray-700 rounded-full cursor-pointer p-1"
+      class="absolute flex items-center hover:bg-gray-200 dark:hover:bg-gray-700 rounded-full cursor-pointer p-1"
+      :class="props.withSearchButton ? 'right-12' : 'right-2'"
     >
       <CloseButton
         @click="handleClear"
@@ -86,6 +91,7 @@ defineExpose({
       />
     </div>
     <button
+      v-if="props.withSearchButton"
       type="button"
       class="absolute inset-y-0 right-0 flex items-center justify-center px-3 border-l border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-default disabled:hover:bg-transparent"
       aria-label="Search"
@@ -99,9 +105,4 @@ defineExpose({
 
 <style scoped>
 @import '@/assets/input.css';
-
-/* Space for clear and search buttons */
-input {
-  padding-right: 5.5rem !important;
-}
 </style>

--- a/src/components/molecules/List.vue
+++ b/src/components/molecules/List.vue
@@ -153,7 +153,3 @@ watch(
     </template>
   </ListContent>
 </template>
-
-<style scoped>
-@import '@/assets/text-highlight.css';
-</style>

--- a/src/components/molecules/SearchInput.test.ts
+++ b/src/components/molecules/SearchInput.test.ts
@@ -269,7 +269,7 @@ describe('SearchInput.vue – exposures and workspaces groups', () => {
     await input.trigger('focus')
     await nextTick()
 
-    expect(wrapper.text()).toContain('No authors orkeywords found for')
+    expect(wrapper.text()).toContain('No authors or keywords found for')
 
     wrapper.unmount()
   })

--- a/src/components/molecules/SearchInput.test.ts
+++ b/src/components/molecules/SearchInput.test.ts
@@ -328,6 +328,52 @@ describe('SearchInput.vue – exposures and workspaces groups', () => {
     wrapper.unmount()
   })
 
+  it('can focus first category "... more" toggle by tabbing from its last visible term', async () => {
+    mockSearchCategories.push({
+      kind: 'citation_author_family_name',
+      loading: false,
+      kindInfo: {
+        terms: [
+          'Noble 1',
+          'Noble 2',
+          'Noble 3',
+          'Noble 4',
+          'Noble 5',
+          'Noble 6',
+          'Noble 7',
+          'Noble 8',
+          'Noble 9',
+          'Noble 10',
+          'Noble 11',
+        ],
+      },
+    })
+
+    const wrapper = mountSearchInput()
+    await flushPromises()
+
+    const input = wrapper.find('input')
+    await input.setValue('Noble')
+    await input.trigger('focus')
+    await nextTick()
+
+    const termButtons = wrapper.findAll('button.term-button')
+    const lastVisibleTermButton = termButtons[termButtons.length - 1]
+    const moreButton = wrapper.findAll('button').find((b) => b.text().trim() === '... more')
+
+    expect(lastVisibleTermButton).toBeDefined()
+    expect(moreButton).toBeDefined()
+
+    await lastVisibleTermButton?.trigger('focus')
+    await nextTick()
+    await lastVisibleTermButton?.trigger('keydown', { key: 'Tab' })
+    await nextTick()
+
+    expect(document.activeElement).toBe(moreButton?.element)
+
+    wrapper.unmount()
+  })
+
   it('uses singular form "exposure" when count is one', async () => {
     const wrapper = mountSearchInput()
     await flushPromises()

--- a/src/components/molecules/SearchInput.test.ts
+++ b/src/components/molecules/SearchInput.test.ts
@@ -374,6 +374,113 @@ describe('SearchInput.vue – exposures and workspaces groups', () => {
     wrapper.unmount()
   })
 
+  it('moves focus to the first newly revealed term when pressing Enter on "... more"', async () => {
+    mockSearchCategories.push({
+      kind: 'citation_author_family_name',
+      loading: false,
+      kindInfo: {
+        terms: [
+          'Noble 1',
+          'Noble 2',
+          'Noble 3',
+          'Noble 4',
+          'Noble 5',
+          'Noble 6',
+          'Noble 7',
+          'Noble 8',
+          'Noble 9',
+          'Noble 10',
+          'Noble 11',
+        ],
+      },
+    })
+
+    const wrapper = mountSearchInput()
+    await flushPromises()
+
+    const input = wrapper.find('input')
+    await input.setValue('Noble')
+    await input.trigger('focus')
+    await nextTick()
+
+    const moreButton = wrapper.findAll('button').find((b) => b.text().trim() === '... more')
+    expect(moreButton).toBeDefined()
+
+    await moreButton?.trigger('focus')
+    await nextTick()
+    await moreButton?.trigger('keydown', { key: 'Enter' })
+    await nextTick()
+
+    expect(document.activeElement?.textContent?.trim()).toBe('Noble 11')
+
+    wrapper.unmount()
+  })
+
+  it('keeps focus on "Show less" after Enter so next Tab goes to next category term', async () => {
+    mockSearchCategories.push(
+      {
+        kind: 'citation_author_family_name',
+        loading: false,
+        kindInfo: {
+          terms: [
+            'Alpha 1',
+            'Alpha 2',
+            'Alpha 3',
+            'Alpha 4',
+            'Alpha 5',
+            'Alpha 6',
+            'Alpha 7',
+            'Alpha 8',
+            'Alpha 9',
+            'Alpha 10',
+            'Alpha 11',
+          ],
+        },
+      },
+      {
+        kind: 'cellml_keyword',
+        loading: false,
+        kindInfo: {
+          terms: ['Alpha keyword'],
+        },
+      },
+    )
+
+    const wrapper = mountSearchInput()
+    await flushPromises()
+
+    const input = wrapper.find('input')
+    await input.setValue('Alpha')
+    await input.trigger('focus')
+    await nextTick()
+
+    let moreButton = wrapper.findAll('button').find((b) => b.text().trim() === '... more')
+    expect(moreButton).toBeDefined()
+
+    await moreButton?.trigger('focus')
+    await nextTick()
+    await moreButton?.trigger('keydown', { key: 'Enter' })
+    await nextTick()
+
+    const showLessButton = wrapper.findAll('button').find((b) => b.text().trim() === 'Show less')
+    expect(showLessButton).toBeDefined()
+
+    await showLessButton?.trigger('focus')
+    await nextTick()
+    await showLessButton?.trigger('keydown', { key: 'Enter' })
+    await nextTick()
+
+    moreButton = wrapper.findAll('button').find((b) => b.text().trim() === '... more')
+    expect(moreButton).toBeDefined()
+    expect(document.activeElement).toBe(moreButton?.element)
+
+    await moreButton?.trigger('keydown', { key: 'Tab' })
+    await nextTick()
+    expect(document.activeElement?.textContent?.trim()).toBe('Alpha keyword')
+
+    wrapper.unmount()
+  })
+
   it('uses singular form "exposure" when count is one', async () => {
     const wrapper = mountSearchInput()
     await flushPromises()

--- a/src/components/molecules/SearchInput.test.ts
+++ b/src/components/molecules/SearchInput.test.ts
@@ -303,10 +303,27 @@ describe('SearchInput.vue – exposures and workspaces groups', () => {
     await input.trigger('focus')
     await nextTick()
 
-    const termButtons = wrapper.findAll('button.term-button')
+    let termButtons = wrapper.findAll('button.term-button')
     expect(termButtons).toHaveLength(10)
     expect(wrapper.text()).toContain('Noble 10')
     expect(wrapper.text()).not.toContain('Noble 11')
+
+    const moreButton = wrapper.findAll('button').find((b) => b.text().trim() === '... more')
+    expect(moreButton).toBeDefined()
+    await moreButton?.trigger('click')
+    await nextTick()
+
+    termButtons = wrapper.findAll('button.term-button')
+    expect(termButtons).toHaveLength(11)
+
+    const lessButton = wrapper.findAll('button').find((b) => b.text().trim() === 'Show less')
+    expect(lessButton).toBeDefined()
+    await lessButton?.trigger('click')
+    await nextTick()
+
+    termButtons = wrapper.findAll('button.term-button')
+    expect(termButtons).toHaveLength(10)
+    expect(wrapper.findAll('button').some((b) => b.text().trim() === '... more')).toBe(true)
 
     wrapper.unmount()
   })

--- a/src/components/molecules/SearchInput.test.ts
+++ b/src/components/molecules/SearchInput.test.ts
@@ -269,7 +269,7 @@ describe('SearchInput.vue – exposures and workspaces groups', () => {
     await input.trigger('focus')
     await nextTick()
 
-    expect(wrapper.text()).toContain('No suggestions found')
+    expect(wrapper.text()).toContain('No keywords or authors found for')
 
     wrapper.unmount()
   })

--- a/src/components/molecules/SearchInput.test.ts
+++ b/src/components/molecules/SearchInput.test.ts
@@ -269,7 +269,44 @@ describe('SearchInput.vue – exposures and workspaces groups', () => {
     await input.trigger('focus')
     await nextTick()
 
-    expect(wrapper.text()).toContain('No matching results found')
+    expect(wrapper.text()).toContain('No suggestions found')
+
+    wrapper.unmount()
+  })
+
+  it('limits each category group to ten term suggestions', async () => {
+    mockSearchCategories.push({
+      kind: 'citation_author_family_name',
+      loading: false,
+      kindInfo: {
+        terms: [
+          'Noble 1',
+          'Noble 2',
+          'Noble 3',
+          'Noble 4',
+          'Noble 5',
+          'Noble 6',
+          'Noble 7',
+          'Noble 8',
+          'Noble 9',
+          'Noble 10',
+          'Noble 11',
+        ],
+      },
+    })
+
+    const wrapper = mountSearchInput()
+    await flushPromises()
+
+    const input = wrapper.find('input')
+    await input.setValue('Noble')
+    await input.trigger('focus')
+    await nextTick()
+
+    const termButtons = wrapper.findAll('button.term-button')
+    expect(termButtons).toHaveLength(10)
+    expect(wrapper.text()).toContain('Noble 10')
+    expect(wrapper.text()).not.toContain('Noble 11')
 
     wrapper.unmount()
   })

--- a/src/components/molecules/SearchInput.test.ts
+++ b/src/components/molecules/SearchInput.test.ts
@@ -349,44 +349,38 @@ describe('SearchInput.vue – getMatchingCount logic', () => {
     wrapper.unmount()
   })
 
-  it('uses valid initialKind as fallback search kind when no category matches are found', async () => {
+  it('emits querySearch when SearchField emits search', async () => {
     const wrapper = mountSearchInput('Noble', 'model_author')
     await flushPromises()
 
     wrapper.findComponent({ name: 'SearchField' }).vm.$emit('search')
     await nextTick()
 
-    expect(wrapper.emitted('search')?.[0]).toEqual(['model_author', 'Noble'])
+    expect(wrapper.emitted('querySearch')?.[0]).toEqual(['Noble'])
 
     wrapper.unmount()
   })
 
-  it('falls back to citation_id when initialKind is invalid and no category matches are found', async () => {
-    const wrapper = mountSearchInput('Noble', 'not_a_real_kind')
+  it('trims query text before emitting querySearch from SearchField search event', async () => {
+    const wrapper = mountSearchInput('  Noble  ', 'not_a_real_kind')
     await flushPromises()
 
     wrapper.findComponent({ name: 'SearchField' }).vm.$emit('search')
     await nextTick()
 
-    expect(wrapper.emitted('search')?.[0]).toEqual(['citation_id', 'Noble'])
+    expect(wrapper.emitted('querySearch')?.[0]).toEqual(['Noble'])
 
     wrapper.unmount()
   })
 
-  it('prefers the first matching category kind over initialKind', async () => {
-    mockSearchCategories.push({
-      kind: 'cellml_keyword',
-      loading: false,
-      kindInfo: { terms: ['Noble keyword'] },
-    })
-
-    const wrapper = mountSearchInput('Noble', 'model_author')
+  it('does not emit querySearch when SearchField emits search with empty query', async () => {
+    const wrapper = mountSearchInput('   ', 'model_author')
     await flushPromises()
 
     wrapper.findComponent({ name: 'SearchField' }).vm.$emit('search')
     await nextTick()
 
-    expect(wrapper.emitted('search')?.[0]).toEqual(['cellml_keyword', 'Noble'])
+    expect(wrapper.emitted('querySearch')).toBeUndefined()
 
     wrapper.unmount()
   })

--- a/src/components/molecules/SearchInput.test.ts
+++ b/src/components/molecules/SearchInput.test.ts
@@ -269,7 +269,7 @@ describe('SearchInput.vue – exposures and workspaces groups', () => {
     await input.trigger('focus')
     await nextTick()
 
-    expect(wrapper.text()).toContain('No keywords or authors found for')
+    expect(wrapper.text()).toContain('No authors orkeywords found for')
 
     wrapper.unmount()
   })

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -294,8 +294,8 @@ defineExpose({
       @click="handleBackdropClick"
     ></div>
     <div
-      class="flex items-center bg-background justify-between w-full border rounded-lg transition-all relative z-40"
-      :class="isSearchFocused ? 'ring-2 ring-primary border-transparent' : 'border-gray-200 dark:border-gray-700 overflow-hidden'"
+      class="flex items-center bg-background justify-between w-full border rounded-lg transition-all relative z-40 overflow-hidden"
+      :class="isSearchFocused ? 'ring-1 ring-primary border-primary' : 'border-gray-200 dark:border-gray-700'"
     >
       <SearchField
         ref="searchInputRef"

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -9,7 +9,7 @@ import {
   watch,
 } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import Keycap from '@/components/atoms/Keycap.vue'
+import SearchEnterHint from '@/components/atoms/SearchEnterHint.vue'
 import SearchField from '@/components/atoms/SearchField.vue'
 import TermButton from '@/components/atoms/TermButton.vue'
 import { SEARCH_CATEGORIES } from '@/constants/search'
@@ -333,17 +333,13 @@ defineExpose({
           <p class="text-gray-500 dark:text-gray-400 text-sm">
             No keywords or authors found for
             <span class="text-gray-700 dark:text-gray-200 font-semibold">"{{ searchInput }}"</span>.
-            Press <Keycap>Enter</Keycap> to search for
-            <span class="text-gray-700 dark:text-gray-200 font-semibold">"{{ searchInput }}"</span>
-            anywhere in the repository.
+            <SearchEnterHint :query="searchInput" />
           </p>
         </div>
         <div v-else class="max-h-96 overflow-y-auto scrollbar-thin group/results">
           <div class="p-4 border-b border-gray-200 dark:border-gray-700" v-if="!props.inOverlay">
             <p class="text-gray-500 dark:text-gray-400 text-sm">
-              Press <Keycap>Enter</Keycap> to search for
-              <span class="text-gray-700 dark:text-gray-200 font-semibold">"{{ searchInput }}"</span>
-              anywhere in the repository{{ termTypeSuffix }}.
+              <SearchEnterHint :query="searchInput" :suffix="termTypeSuffix" />
             </p>
           </div>
           <div

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -233,6 +233,7 @@ const handleSearchInputKeyDown = async (event: KeyboardEvent) => {
     event.preventDefault()
     const searchQuery = searchInput.value.trim()
     if (searchQuery) {
+      searchInputRef.value?.inputRef?.blur()
       isSearchFocused.value = false
       emit('querySearch', searchQuery)
     }

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -54,6 +54,7 @@ const categoriesError = ref<string | null>(null)
 const termButtonRefs = ref<InstanceType<typeof TermButton>[]>([])
 const exposuresButtonRef = ref<HTMLButtonElement | null>(null)
 const workspacesButtonRef = ref<HTMLButtonElement | null>(null)
+const expandedCategoryKinds = ref<Record<string, boolean>>({})
 
 const setTermButtonRef = (el: Element | ComponentPublicInstance | null, index: number) => {
   if (el) {
@@ -102,13 +103,25 @@ const filteredSearchTermsByCategory = computed(() => {
       (term) => isValidTerm(term) && term.toLowerCase().includes(searchTermValue),
     )
 
+    const totalCount = filteredTerms.length
+    const isExpanded = Boolean(expandedCategoryKinds.value[category.value])
+
     return {
       kind: category.value,
       label: category.label,
-      terms: filteredTerms.slice(0, MAX_TERMS_PER_CATEGORY),
+      terms: isExpanded ? filteredTerms : filteredTerms.slice(0, MAX_TERMS_PER_CATEGORY),
+      totalCount,
+      hasMore: totalCount > MAX_TERMS_PER_CATEGORY && !isExpanded,
     }
   }).filter((group) => group.terms.length > 0)
 })
+
+const handleShowMoreTerms = (kind: string) => {
+  expandedCategoryKinds.value = {
+    ...expandedCategoryKinds.value,
+    [kind]: true,
+  }
+}
 
 const getMatchingCount = <T extends SortableEntity>(items: T[], query: string): number => {
   const normalisedQuery = normaliseSearchText(query)
@@ -274,6 +287,13 @@ watch(isSearchFocused, (newVal) => {
   }
 })
 
+watch(
+  () => searchInput.value,
+  () => {
+    expandedCategoryKinds.value = {}
+  },
+)
+
 watch(filteredSearchTermsByCategory, () => {
   termButtonRefs.value = []
   exposuresButtonRef.value = null
@@ -359,6 +379,14 @@ defineExpose({
                   :term="term"
                   @click="handleSearchTermClick(categoryGroup.kind, term)"
                 />
+                <button
+                  v-if="categoryGroup.hasMore"
+                  type="button"
+                  class="px-3 py-1.5 rounded-md text-sm transition-colors relative focus:outline-none cursor-pointer text-primary hover:text-primary-hover border border-dashed border-gray-300 dark:border-gray-600 bg-transparent hover:bg-gray-50 dark:hover:bg-gray-900/40 hover:border-gray-400 dark:hover:border-gray-500"
+                  @click="handleShowMoreTerms(categoryGroup.kind)"
+                >
+                  Show more
+                </button>
               </div>
             </div>
             <div

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -323,7 +323,7 @@ defineExpose({
         </div>
         <div v-else-if="!hasResults" class="p-4">
           <p class="text-gray-500 dark:text-gray-400">
-            No matching results found for "{{ searchInput }}".
+            No suggestions found for ‘{{ searchInput }}’. Press Enter to search.
           </p>
         </div>
         <div v-else class="max-h-96 overflow-y-auto scrollbar-thin group/results">

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -112,7 +112,6 @@ const filteredSearchTermsByCategory = computed(() => {
       terms: isExpanded ? filteredTerms : filteredTerms.slice(0, MAX_TERMS_PER_CATEGORY),
       totalCount,
       isExpanded,
-      hasMore: totalCount > MAX_TERMS_PER_CATEGORY && !isExpanded,
     }
   }).filter((group) => group.terms.length > 0)
 })

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -126,6 +126,23 @@ const workspacesCount = computed(() =>
   getMatchingCount(workspaceStore.workspaces, searchInput.value.trim()),
 )
 
+// Build a human-readable label for the types of term results currently shown,
+// e.g. "keyword", "author", or "keyword or author". Returns null when no term
+// groups are present (only exposure/workspace counts are shown).
+const availableTermTypeLabel = computed<string | null>(() => {
+  const kinds = new Set(filteredSearchTermsByCategory.value.map((g) => g.kind))
+  const hasKeyword = kinds.has('cellml_keyword')
+  const hasAuthor = kinds.has('citation_author_family_name') || kinds.has('model_author')
+  if (hasKeyword && hasAuthor) return 'an author or keyword'
+  if (hasKeyword) return 'a keyword'
+  if (hasAuthor) return 'an author'
+  return null
+})
+
+const termTypeSuffix = computed(() =>
+  availableTermTypeLabel.value ? `, or select ${availableTermTypeLabel.value} below` : '',
+)
+
 const hasResults = computed(() => {
   return (
     filteredSearchTermsByCategory.value.length > 0 ||
@@ -322,7 +339,7 @@ defineExpose({
         <div v-else class="max-h-96 overflow-y-auto scrollbar-thin group/results">
           <div class="p-4 border-b border-gray-200 dark:border-gray-700" v-if="!props.inOverlay">
             <p class="text-gray-500 dark:text-gray-400 text-sm">
-              Press <Keycap>Enter</Keycap> to search, or select a keyword or author below.
+              Press <Keycap>Enter</Keycap> to search{{ termTypeSuffix }}.
             </p>
           </div>
           <div

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -196,10 +196,10 @@ const availableTermTypeLabel = computed<string | null>(() => {
   if (kinds.has('cellml_keyword')) parts.push('keyword')
   if (kinds.has('citation_id')) parts.push('publication reference')
   if (parts.length === 0) return null
-  const article = parts[0] === 'author' ? 'an' : 'a'
-  if (parts.length === 1) return `${article} ${parts[0]}`
+  const formatPart = (part: string): string => (part === 'author' ? 'an author' : `a ${part}`)
+  if (parts.length === 1) return formatPart(parts[0])
   const last = parts.pop()
-  return `${article} ${parts.join(' or ')} or ${last}`
+  return `${parts.map(formatPart).join(' or ')} or ${formatPart(last ?? '')}`
 })
 
 const termTypeSuffix = computed(() =>

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -351,7 +351,7 @@ defineExpose({
         </div>
         <div v-else-if="!hasResults" class="p-4">
           <p class="text-gray-500 dark:text-gray-400 text-sm">
-            No keywords or authors found for
+            No authors orkeywords found for
             <span class="text-gray-700 dark:text-gray-200 font-semibold">"{{ searchInput }}"</span>.
             <SearchEnterHint :query="searchInput" />
           </p>

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -336,7 +336,7 @@ defineExpose({
             <SearchEnterHint :query="searchInput" />
           </p>
         </div>
-        <div v-else class="max-h-96 overflow-y-auto scrollbar-thin group/results">
+        <div v-else class="max-h-96 bg-background overflow-y-auto scrollbar-thin group/results">
           <div class="p-4 border-b border-gray-200 dark:border-gray-700" v-if="!props.inOverlay">
             <p class="text-gray-500 dark:text-gray-400 text-sm">
               <SearchEnterHint :query="searchInput" :suffix="termTypeSuffix" />

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -333,16 +333,17 @@ defineExpose({
           <p class="text-gray-500 dark:text-gray-400 text-sm">
             No keywords or authors found for
             <span class="text-gray-700 dark:text-gray-200 font-semibold">"{{ searchInput }}"</span>.
-            Press <Keycap>Enter</Keycap>
-            to search for
-            <span class="text-gray-700 dark:text-gray-200 font-semibold">"{{ searchInput }}"</span> anywhere in
-            the repository.
+            Press <Keycap>Enter</Keycap> to search for
+            <span class="text-gray-700 dark:text-gray-200 font-semibold">"{{ searchInput }}"</span>
+            anywhere in the repository.
           </p>
         </div>
         <div v-else class="max-h-96 overflow-y-auto scrollbar-thin group/results">
           <div class="p-4 border-b border-gray-200 dark:border-gray-700" v-if="!props.inOverlay">
             <p class="text-gray-500 dark:text-gray-400 text-sm">
-              Press <Keycap>Enter</Keycap> to search{{ termTypeSuffix }}.
+              Press <Keycap>Enter</Keycap> to search for
+              <span class="text-gray-700 dark:text-gray-200 font-semibold">"{{ searchInput }}"</span>
+              anywhere in the repository{{ termTypeSuffix }}.
             </p>
           </div>
           <div

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -231,6 +231,7 @@ const handleSearchInputKeyDown = async (event: KeyboardEvent) => {
     event.preventDefault()
     const searchQuery = searchInput.value.trim()
     if (searchQuery) {
+      isSearchFocused.value = false
       emit('querySearch', searchQuery)
     }
     return

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -337,7 +337,7 @@ defineExpose({
           </p>
         </div>
         <div v-else class="max-h-96 bg-background overflow-y-auto scrollbar-thin group/results">
-          <div class="p-4 border-b border-gray-200 dark:border-gray-700" v-if="!props.inOverlay">
+          <div class="p-4 border-b border-gray-200 dark:border-gray-700">
             <p class="text-gray-500 dark:text-gray-400 text-sm">
               <SearchEnterHint :query="searchInput" :suffix="termTypeSuffix" />
             </p>

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -140,7 +140,7 @@ const workspacesCount = computed(() =>
 )
 
 // Build a human-readable label for the types of term results currently shown,
-// e.g. "an author", "a keyword", or "an author, keyword, or publication reference".
+// e.g. "an author", "a keyword", or "an author or keyword or publication reference".
 // Returns null when no term groups are present (only exposure/workspace counts are shown).
 const availableTermTypeLabel = computed<string | null>(() => {
   const kinds = new Set(filteredSearchTermsByCategory.value.map((g) => g.kind))
@@ -152,11 +152,11 @@ const availableTermTypeLabel = computed<string | null>(() => {
   const article = parts[0] === 'author' ? 'an' : 'a'
   if (parts.length === 1) return `${article} ${parts[0]}`
   const last = parts.pop()
-  return `${article} ${parts.join(', ')}, or ${last}`
+  return `${article} ${parts.join(' or ')} or ${last}`
 })
 
 const termTypeSuffix = computed(() =>
-  availableTermTypeLabel.value ? `, or select ${availableTermTypeLabel.value} below` : '',
+  availableTermTypeLabel.value ? ` or select ${availableTermTypeLabel.value} below` : '',
 )
 
 const hasResults = computed(() => {

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -330,6 +330,11 @@ defineExpose({
           </p>
         </div>
         <div v-else class="max-h-96 overflow-y-auto scrollbar-thin group/results">
+          <div class="p-4 border-b border-gray-200 dark:border-gray-700">
+            <p class="text-gray-500 dark:text-gray-400 text-sm">
+              Press Enter to search or click a suggestion below.
+            </p>
+          </div>
           <div
             v-for="(categoryGroup, groupIndex) in filteredSearchTermsByCategory"
             :key="categoryGroup.kind"

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -111,15 +111,16 @@ const filteredSearchTermsByCategory = computed(() => {
       label: category.label,
       terms: isExpanded ? filteredTerms : filteredTerms.slice(0, MAX_TERMS_PER_CATEGORY),
       totalCount,
+      isExpanded,
       hasMore: totalCount > MAX_TERMS_PER_CATEGORY && !isExpanded,
     }
   }).filter((group) => group.terms.length > 0)
 })
 
-const handleShowMoreTerms = (kind: string) => {
+const handleToggleTerms = (kind: string) => {
   expandedCategoryKinds.value = {
     ...expandedCategoryKinds.value,
-    [kind]: true,
+    [kind]: !expandedCategoryKinds.value[kind],
   }
 }
 
@@ -368,9 +369,20 @@ defineExpose({
               :key="categoryGroup.kind"
               class="result-group"
             >
-              <h4 class="font-semibold text-gray-700 dark:text-gray-300 mb-3">
-                {{ categoryGroup.label }}
-              </h4>
+              <div class="mb-3 flex items-start justify-between gap-3">
+                <h4 class="font-semibold text-gray-700 dark:text-gray-300">
+                  {{ categoryGroup.label }}
+                </h4>
+                <button
+                  v-if="categoryGroup.totalCount > MAX_TERMS_PER_CATEGORY"
+                  type="button"
+                  class="px-3 py-1 text-sm transition-colors relative focus:outline-none cursor-pointer text-primary hover:text-primary-hover bg-transparent"
+                  :aria-expanded="categoryGroup.isExpanded"
+                  @click="handleToggleTerms(categoryGroup.kind)"
+                >
+                  {{ categoryGroup.isExpanded ? 'Show less' : '... more' }}
+                </button>
+              </div>
               <div class="flex flex-row items-start justify-start flex-wrap gap-2">
                 <TermButton
                   v-for="(term, termIndex) in categoryGroup.terms"
@@ -379,14 +391,6 @@ defineExpose({
                   :term="term"
                   @click="handleSearchTermClick(categoryGroup.kind, term)"
                 />
-                <button
-                  v-if="categoryGroup.hasMore"
-                  type="button"
-                  class="px-3 py-1.5 rounded-md text-sm transition-colors relative focus:outline-none cursor-pointer text-primary hover:text-primary-hover border border-dashed border-gray-300 dark:border-gray-600 bg-transparent hover:bg-gray-50 dark:hover:bg-gray-900/40 hover:border-gray-400 dark:hover:border-gray-500"
-                  @click="handleShowMoreTerms(categoryGroup.kind)"
-                >
-                  Show more
-                </button>
               </div>
             </div>
             <div

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -336,61 +336,63 @@ defineExpose({
             <SearchEnterHint :query="searchInput" />
           </p>
         </div>
-        <div v-else class="max-h-96 bg-background overflow-y-auto scrollbar-thin group/results">
+        <div v-else class="max-h-96 bg-background overflow-y-auto scrollbar-thin">
           <div class="p-4 border-b border-gray-200 dark:border-gray-700">
             <p class="text-gray-500 dark:text-gray-400 text-sm">
               <SearchEnterHint :query="searchInput" :suffix="termTypeSuffix" />
             </p>
           </div>
-          <div
-            v-for="(categoryGroup, groupIndex) in filteredSearchTermsByCategory"
-            :key="categoryGroup.kind"
-            class="result-group"
-          >
-            <h4 class="font-semibold text-gray-700 dark:text-gray-300 mb-3">
-              {{ categoryGroup.label }}
-            </h4>
-            <div class="flex flex-row items-start justify-start flex-wrap gap-2">
-              <TermButton
-                v-for="(term, termIndex) in categoryGroup.terms"
-                :key="term"
-                :ref="(el) => setTermButtonRef(el, filteredSearchTermsByCategory.slice(0, groupIndex).reduce((acc, g) => acc + g.terms.length, 0) + termIndex)"
-                :term="term"
-                @click="handleSearchTermClick(categoryGroup.kind, term)"
-              />
+          <div class="group/results">
+            <div
+              v-for="(categoryGroup, groupIndex) in filteredSearchTermsByCategory"
+              :key="categoryGroup.kind"
+              class="result-group"
+            >
+              <h4 class="font-semibold text-gray-700 dark:text-gray-300 mb-3">
+                {{ categoryGroup.label }}
+              </h4>
+              <div class="flex flex-row items-start justify-start flex-wrap gap-2">
+                <TermButton
+                  v-for="(term, termIndex) in categoryGroup.terms"
+                  :key="term"
+                  :ref="(el) => setTermButtonRef(el, filteredSearchTermsByCategory.slice(0, groupIndex).reduce((acc, g) => acc + g.terms.length, 0) + termIndex)"
+                  :term="term"
+                  @click="handleSearchTermClick(categoryGroup.kind, term)"
+                />
+              </div>
             </div>
-          </div>
-          <div
-            v-if="exposuresCount > 0"
-            class="result-group"
-          >
-            <h4 class="font-semibold text-gray-700 dark:text-gray-300 mb-3">
-              Exposures
-            </h4>
-            <button
-              type="button"
-              ref="exposuresButtonRef"
-              class="cursor-pointer text-primary hover:text-primary-hover transition-colors"
-              @click="handleExposuresClick"
+            <div
+              v-if="exposuresCount > 0"
+              class="result-group"
             >
-              See {{ formatNumber(exposuresCount) }} matching exposure{{ exposuresCount !== 1 ? 's' : '' }}
-            </button>
-          </div>
-          <div
-            v-if="workspacesCount > 0"
-            class="result-group"
-          >
-            <h4 class="font-semibold text-gray-700 dark:text-gray-300 mb-3">
-              Workspaces
-            </h4>
-            <button
-              type="button"
-              ref="workspacesButtonRef"
-              class="cursor-pointer text-primary hover:text-primary-hover transition-colors"
-              @click="handleWorkspacesClick"
+              <h4 class="font-semibold text-gray-700 dark:text-gray-300 mb-3">
+                Exposures
+              </h4>
+              <button
+                type="button"
+                ref="exposuresButtonRef"
+                class="cursor-pointer text-primary hover:text-primary-hover transition-colors"
+                @click="handleExposuresClick"
+              >
+                See {{ formatNumber(exposuresCount) }} matching exposure{{ exposuresCount !== 1 ? 's' : '' }}
+              </button>
+            </div>
+            <div
+              v-if="workspacesCount > 0"
+              class="result-group"
             >
-              See {{ formatNumber(workspacesCount) }} matching workspace{{ workspacesCount !== 1 ? 's' : '' }}
-            </button>
+              <h4 class="font-semibold text-gray-700 dark:text-gray-300 mb-3">
+                Workspaces
+              </h4>
+              <button
+                type="button"
+                ref="workspacesButtonRef"
+                class="cursor-pointer text-primary hover:text-primary-hover transition-colors"
+                @click="handleWorkspacesClick"
+              >
+                See {{ formatNumber(workspacesCount) }} matching workspace{{ workspacesCount !== 1 ? 's' : '' }}
+              </button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -138,28 +138,16 @@ const isSuggestionsVisible = computed(() => {
   return props.inOverlay ? true : isSearchFocused.value
 })
 
-const defaultSearchKind = computed(() => {
-  if (SEARCH_CATEGORIES.some((category) => category.value === props.initialKind)) {
-    return props.initialKind
-  }
-  return 'citation_id'
-})
-
-const handleSearch = () => {
-  const searchTerm = searchInput.value.trim()
-  if (searchTerm === '') {
+const handleQuerySearch = () => {
+  const searchQuery = searchInput.value.trim()
+  if (!searchQuery) {
     searchInputRef?.value?.inputRef?.focus()
     return
   }
 
-  // Use the first category kind that has matching results, otherwise prefer
-  // initialKind when valid, and finally fallback to citation_id.
-  const firstCategoryWithResults = filteredSearchTermsByCategory.value[0]
-  const searchKind = firstCategoryWithResults?.kind || defaultSearchKind.value
-
-  // Blur the input to close the dropdown.
-  // searchInputRef.value?.inputRef?.blur()
-  emit('search', searchKind, searchTerm)
+  searchInputRef.value?.inputRef?.blur()
+  isSearchFocused.value = false
+  emit('querySearch', searchQuery)
 }
 
 const handleSearchTermClick = (kind: string, term: string) => {
@@ -231,12 +219,7 @@ const handleKeyDown = (event: KeyboardEvent) => {
 const handleSearchInputKeyDown = async (event: KeyboardEvent) => {
   if (event.key === 'Enter') {
     event.preventDefault()
-    const searchQuery = searchInput.value.trim()
-    if (searchQuery) {
-      searchInputRef.value?.inputRef?.blur()
-      isSearchFocused.value = false
-      emit('querySearch', searchQuery)
-    }
+    handleQuerySearch()
     return
   }
 
@@ -306,7 +289,7 @@ defineExpose({
         input-class="flex-1 min-w-0 outline-none focus:ring-0 px-4 py-2"
         @focus="isSearchFocused = true"
         @blur="isSearchFocused = false"
-        @search="handleSearch"
+        @search="handleQuerySearch"
         @keydown="handleSearchInputKeyDown"
       />
     </div>

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -351,7 +351,7 @@ defineExpose({
         </div>
         <div v-else-if="!hasResults" class="p-4">
           <p class="text-gray-500 dark:text-gray-400 text-sm">
-            No authors orkeywords found for
+            No authors or keywords found for
             <span class="text-gray-700 dark:text-gray-200 font-semibold">"{{ searchInput }}"</span>.
             <SearchEnterHint :query="searchInput" />
           </p>

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -71,12 +71,27 @@ const setToggleButtonRef = (el: Element | ComponentPublicInstance | null, index:
 // per category group), then each category toggle (if shown), then the
 // Exposures button, then the Workspaces button.
 const allSuggestionButtons = computed<HTMLElement[]>(() => {
-  const termEls = termButtonRefs.value.map((ref) => ref?.$el ?? ref).filter(Boolean)
-  const toggleEls = toggleButtonRefs.value.filter(Boolean) as HTMLElement[]
+  const groupedButtons: HTMLElement[] = []
+  let termOffset = 0
+
+  filteredSearchTermsByCategory.value.forEach((group, groupIndex) => {
+    const groupTermEls = termButtonRefs.value
+      .slice(termOffset, termOffset + group.terms.length)
+      .map((ref) => ref?.$el ?? ref)
+      .filter(Boolean) as HTMLElement[]
+    groupedButtons.push(...groupTermEls)
+    termOffset += group.terms.length
+
+    const toggleEl = toggleButtonRefs.value[groupIndex]
+    if (group.totalCount > MAX_TERMS_PER_CATEGORY && toggleEl) {
+      groupedButtons.push(toggleEl)
+    }
+  })
+
   const extras: HTMLElement[] = []
   if (exposuresButtonRef.value) extras.push(exposuresButtonRef.value)
   if (workspacesButtonRef.value) extras.push(workspacesButtonRef.value)
-  return [...termEls, ...toggleEls, ...extras]
+  return [...groupedButtons, ...extras]
 })
 
 onMounted(async () => {
@@ -242,15 +257,22 @@ const handleKeyDown = (event: KeyboardEvent) => {
     if (activeIndex === -1) return
 
     const searchInputEl = searchInputRef.value?.inputRef
+    event.preventDefault()
 
-    if (event.shiftKey && activeIndex === 0) {
-      // Shift+Tab on first term button → go back to search input.
-      event.preventDefault()
-      searchInputEl?.focus()
-    } else if (!event.shiftKey && activeIndex === buttonEls.length - 1) {
-      // Tab on last term button → cycle back to search input.
-      event.preventDefault()
-      searchInputEl?.focus()
+    if (event.shiftKey) {
+      if (activeIndex === 0) {
+        // Shift+Tab on first suggestion button → go back to search input.
+        searchInputEl?.focus()
+      } else {
+        buttonEls[activeIndex - 1]?.focus()
+      }
+    } else {
+      if (activeIndex === buttonEls.length - 1) {
+        // Tab on last suggestion button → cycle back to search input.
+        searchInputEl?.focus()
+      } else {
+        buttonEls[activeIndex + 1]?.focus()
+      }
     }
   }
 }

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -27,6 +27,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   (e: 'search', searchKind: string, searchTerm: string): void
+  (e: 'querySearch', query: string): void
   (e: 'close'): void
 }>()
 
@@ -226,6 +227,15 @@ const handleKeyDown = (event: KeyboardEvent) => {
 
 // Handle Tab/Shift+Tab key to cycle focus between search input and term buttons.
 const handleSearchInputKeyDown = async (event: KeyboardEvent) => {
+  if (event.key === 'Enter') {
+    event.preventDefault()
+    const searchQuery = searchInput.value.trim()
+    if (searchQuery) {
+      emit('querySearch', searchQuery)
+    }
+    return
+  }
+
   if (event.key === 'Tab' && hasResults.value) {
     event.preventDefault()
     await nextTick()

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -144,6 +144,32 @@ const handleToggleTerms = (kind: string) => {
   }
 }
 
+const getGroupTermStartIndex = (groupIndex: number): number => {
+  return filteredSearchTermsByCategory.value
+    .slice(0, groupIndex)
+    .reduce((acc, group) => acc + group.terms.length, 0)
+}
+
+const handleToggleTermsByKeyboard = async (kind: string, groupIndex: number) => {
+  const wasExpanded = Boolean(expandedCategoryKinds.value[kind])
+  handleToggleTerms(kind)
+  await nextTick()
+
+  if (!wasExpanded) {
+    // When expanding from "... more", move focus to the first newly-revealed term.
+    const firstRevealedIndex = getGroupTermStartIndex(groupIndex) + MAX_TERMS_PER_CATEGORY
+    const revealedTerm = termButtonRefs.value[firstRevealedIndex]
+    const revealedTermEl = (revealedTerm?.$el ?? revealedTerm) as HTMLElement | undefined
+    revealedTermEl?.focus()
+    return
+  }
+
+  // When collapsing from "Show less", keep focus on the toggle so next Tab
+  // advances to the next category's first term.
+  const toggleEl = toggleButtonRefs.value[groupIndex]
+  toggleEl?.focus()
+}
+
 const getMatchingCount = <T extends SortableEntity>(items: T[], query: string): number => {
   const normalisedQuery = normaliseSearchText(query)
   // Return 0 for empty or punctuation-only input.
@@ -408,6 +434,7 @@ defineExpose({
                   class="px-3 py-1 text-sm rounded-md transition-colors relative focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-gray-900 cursor-pointer text-primary hover:text-primary-hover bg-transparent"
                   :aria-expanded="categoryGroup.isExpanded"
                   @click="handleToggleTerms(categoryGroup.kind)"
+                  @keydown.enter.prevent="handleToggleTermsByKeyboard(categoryGroup.kind, groupIndex)"
                 >
                   {{ categoryGroup.isExpanded ? 'Show less' : '... more' }}
                 </button>

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -52,6 +52,7 @@ const searchInputRef = ref<InstanceType<typeof SearchField> | null>(null)
 const isSearchFocused = ref(false)
 const categoriesError = ref<string | null>(null)
 const termButtonRefs = ref<InstanceType<typeof TermButton>[]>([])
+const toggleButtonRefs = ref<(HTMLButtonElement | null)[]>([])
 const exposuresButtonRef = ref<HTMLButtonElement | null>(null)
 const workspacesButtonRef = ref<HTMLButtonElement | null>(null)
 const expandedCategoryKinds = ref<Record<string, boolean>>({})
@@ -62,15 +63,20 @@ const setTermButtonRef = (el: Element | ComponentPublicInstance | null, index: n
   }
 }
 
+const setToggleButtonRef = (el: Element | ComponentPublicInstance | null, index: number) => {
+  toggleButtonRefs.value[index] = el as HTMLButtonElement | null
+}
+
 // All focusable suggestion buttons in focus order: TermButtons first (rendered
-// per category group), then the Exposures button, then the Workspaces button.
-// This matches the DOM order used in the template.
+// per category group), then each category toggle (if shown), then the
+// Exposures button, then the Workspaces button.
 const allSuggestionButtons = computed<HTMLElement[]>(() => {
   const termEls = termButtonRefs.value.map((ref) => ref?.$el ?? ref).filter(Boolean)
+  const toggleEls = toggleButtonRefs.value.filter(Boolean) as HTMLElement[]
   const extras: HTMLElement[] = []
   if (exposuresButtonRef.value) extras.push(exposuresButtonRef.value)
   if (workspacesButtonRef.value) extras.push(workspacesButtonRef.value)
-  return [...termEls, ...extras]
+  return [...termEls, ...toggleEls, ...extras]
 })
 
 onMounted(async () => {
@@ -296,6 +302,7 @@ watch(
 
 watch(filteredSearchTermsByCategory, () => {
   termButtonRefs.value = []
+  toggleButtonRefs.value = []
   exposuresButtonRef.value = null
   workspacesButtonRef.value = null
 })
@@ -375,7 +382,8 @@ defineExpose({
                 <button
                   v-if="categoryGroup.totalCount > MAX_TERMS_PER_CATEGORY"
                   type="button"
-                  class="px-3 py-1 text-sm transition-colors relative focus:outline-none cursor-pointer text-primary hover:text-primary-hover bg-transparent"
+                  :ref="(el) => setToggleButtonRef(el, groupIndex)"
+                  class="px-3 py-1 text-sm rounded-md transition-colors relative focus:outline-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-gray-900 cursor-pointer text-primary hover:text-primary-hover bg-transparent"
                   :aria-expanded="categoryGroup.isExpanded"
                   @click="handleToggleTerms(categoryGroup.kind)"
                 >

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -127,16 +127,19 @@ const workspacesCount = computed(() =>
 )
 
 // Build a human-readable label for the types of term results currently shown,
-// e.g. "keyword", "author", or "keyword or author". Returns null when no term
-// groups are present (only exposure/workspace counts are shown).
+// e.g. "an author", "a keyword", or "an author, keyword, or publication reference".
+// Returns null when no term groups are present (only exposure/workspace counts are shown).
 const availableTermTypeLabel = computed<string | null>(() => {
   const kinds = new Set(filteredSearchTermsByCategory.value.map((g) => g.kind))
-  const hasKeyword = kinds.has('cellml_keyword')
-  const hasAuthor = kinds.has('citation_author_family_name') || kinds.has('model_author')
-  if (hasKeyword && hasAuthor) return 'an author or keyword'
-  if (hasKeyword) return 'a keyword'
-  if (hasAuthor) return 'an author'
-  return null
+  const parts: string[] = []
+  if (kinds.has('citation_author_family_name') || kinds.has('model_author')) parts.push('author')
+  if (kinds.has('cellml_keyword')) parts.push('keyword')
+  if (kinds.has('citation_id')) parts.push('publication reference')
+  if (parts.length === 0) return null
+  const article = parts[0] === 'author' ? 'an' : 'a'
+  if (parts.length === 1) return `${article} ${parts[0]}`
+  const last = parts.pop()
+  return `${article} ${parts.join(', ')}, or ${last}`
 })
 
 const termTypeSuffix = computed(() =>

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -9,6 +9,7 @@ import {
   watch,
 } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import Keycap from '@/components/atoms/Keycap.vue'
 import SearchField from '@/components/atoms/SearchField.vue'
 import TermButton from '@/components/atoms/TermButton.vue'
 import { SEARCH_CATEGORIES } from '@/constants/search'
@@ -309,14 +310,19 @@ defineExpose({
           <p class="text-gray-500 dark:text-gray-400">Loading...</p>
         </div>
         <div v-else-if="!hasResults" class="p-4">
-          <p class="text-gray-500 dark:text-gray-400">
-            No suggestions found for ‘{{ searchInput }}’. Press Enter to search.
+          <p class="text-gray-500 dark:text-gray-400 text-sm">
+            No keywords or authors found for
+            <span class="text-gray-700 dark:text-gray-200 font-semibold">"{{ searchInput }}"</span>.
+            Press <Keycap>Enter</Keycap>
+            to search for
+            <span class="text-gray-700 dark:text-gray-200 font-semibold">"{{ searchInput }}"</span> anywhere in
+            the repository.
           </p>
         </div>
         <div v-else class="max-h-96 overflow-y-auto scrollbar-thin group/results">
           <div class="p-4 border-b border-gray-200 dark:border-gray-700" v-if="!props.inOverlay">
             <p class="text-gray-500 dark:text-gray-400 text-sm">
-              Press Enter to search or click a suggestion below.
+              Press <Keycap>Enter</Keycap> to search, or select a keyword or author below.
             </p>
           </div>
           <div

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -37,6 +37,8 @@ const searchStore = useSearchStore()
 const exposureStore = useExposureStore()
 const workspaceStore = useWorkspaceStore()
 
+const MAX_TERMS_PER_CATEGORY = 10
+
 const searchInput = ref<string>(props.initialTerm)
 
 watch(
@@ -102,7 +104,7 @@ const filteredSearchTermsByCategory = computed(() => {
     return {
       kind: category.value,
       label: category.label,
-      terms: filteredTerms,
+      terms: filteredTerms.slice(0, MAX_TERMS_PER_CATEGORY),
     }
   }).filter((group) => group.terms.length > 0)
 })

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -287,6 +287,7 @@ defineExpose({
         aria-label="Search term"
         class="flex-1"
         input-class="flex-1 min-w-0 outline-none focus:ring-0 px-4 py-2"
+        :with-search-button="true"
         @focus="isSearchFocused = true"
         @blur="isSearchFocused = false"
         @search="handleQuerySearch"

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -330,7 +330,7 @@ defineExpose({
           </p>
         </div>
         <div v-else class="max-h-96 overflow-y-auto scrollbar-thin group/results">
-          <div class="p-4 border-b border-gray-200 dark:border-gray-700">
+          <div class="p-4 border-b border-gray-200 dark:border-gray-700" v-if="!props.inOverlay">
             <p class="text-gray-500 dark:text-gray-400 text-sm">
               Press Enter to search or click a suggestion below.
             </p>

--- a/src/components/molecules/SearchResults.vue
+++ b/src/components/molecules/SearchResults.vue
@@ -158,6 +158,11 @@ const isIdActive = (ids: string[] | undefined) => {
               </template>
             </small>
           </div>
+
+          <div v-if="item.data._brief" v-html="item.data._brief[0]"
+            class="mt-2 text-sm text-gray-600 dark:text-gray-400"
+          ></div>
+
           <div v-if="item.data.cellml_keyword?.length" class="flex flex-wrap gap-2 mt-2">
             <TermButton
               v-for="keyword in item.data.cellml_keyword.filter(k => k.trim())"

--- a/src/components/molecules/SearchResults.vue
+++ b/src/components/molecules/SearchResults.vue
@@ -162,7 +162,7 @@ const isIdActive = (ids: string[] | undefined) => {
           <div
             v-if="item.data._brief?.length"
             v-html="item.data._brief[0]"
-            class="brief-content mt-2 text-sm text-gray-600 dark:text-gray-400"
+            class="mt-2 text-sm text-gray-600 dark:text-gray-400"
           ></div>
 
           <div v-if="item.data.cellml_keyword?.length" class="flex flex-wrap gap-2 mt-2">
@@ -183,8 +183,4 @@ const isIdActive = (ids: string[] | undefined) => {
 <style scoped>
 @import '@/assets/box.css';
 @import '@/assets/text-highlight.css';
-
-.brief-content :deep(mark) {
-  @apply bg-amber-200 dark:bg-amber-400 text-accent;
-}
 </style>

--- a/src/components/molecules/SearchResults.vue
+++ b/src/components/molecules/SearchResults.vue
@@ -182,5 +182,4 @@ const isIdActive = (ids: string[] | undefined) => {
 
 <style scoped>
 @import '@/assets/box.css';
-@import '@/assets/text-highlight.css';
 </style>

--- a/src/components/molecules/SearchResults.vue
+++ b/src/components/molecules/SearchResults.vue
@@ -159,8 +159,10 @@ const isIdActive = (ids: string[] | undefined) => {
             </small>
           </div>
 
-          <div v-if="item.data._brief" v-html="item.data._brief[0]"
-            class="mt-2 text-sm text-gray-600 dark:text-gray-400"
+          <div
+            v-if="item.data._brief?.length"
+            v-html="item.data._brief[0]"
+            class="brief-content mt-2 text-sm text-gray-600 dark:text-gray-400"
           ></div>
 
           <div v-if="item.data.cellml_keyword?.length" class="flex flex-wrap gap-2 mt-2">
@@ -181,4 +183,8 @@ const isIdActive = (ids: string[] | undefined) => {
 <style scoped>
 @import '@/assets/box.css';
 @import '@/assets/text-highlight.css';
+
+.brief-content :deep(mark) {
+  @apply bg-amber-200 dark:bg-amber-400 text-accent;
+}
 </style>

--- a/src/components/molecules/SearchResults.vue
+++ b/src/components/molecules/SearchResults.vue
@@ -6,7 +6,7 @@ import FileIcon from '@/components/icons/FileIcon.vue'
 import ListContent from '@/components/molecules/ListContent.vue'
 import ListItem from '@/components/molecules/ListItem.vue'
 import { SEARCH_KIND_LABEL_MAP } from '@/constants/search'
-import type { SearchResult } from '@/types/search'
+import type { SearchFilter, SearchResult } from '@/types/search'
 import { getExposureIdFromResourcePath } from '@/utils/exposure'
 import { formatDate, formatNumber } from '@/utils/format'
 import { buildSearchQuery, isValidTerm } from '@/utils/search'
@@ -18,6 +18,7 @@ interface Props {
   term: string
   kind: string
   query?: string
+  filters?: SearchFilter[]
 }
 
 const props = defineProps<Props>()
@@ -43,6 +44,22 @@ const resultsCount = computed(() => props.results.length)
 
 const hasResults = computed(() => resultsCount.value > 0)
 
+const hasActiveSearch = computed(() => {
+  return !!(props.query?.trim() || props.filters?.length || props.term.trim())
+})
+
+const activeFilters = computed(() => props.filters ?? [])
+
+const groupedFilters = computed(() => {
+  const groups = new Map<string, string[]>()
+  for (const filter of activeFilters.value) {
+    const terms = groups.get(filter.kind) ?? []
+    terms.push(filter.term)
+    groups.set(filter.kind, terms)
+  }
+  return Array.from(groups.entries()).map(([kind, terms]) => ({ kind, terms }))
+})
+
 const isIdActive = (ids: string[] | undefined) => {
   if (!ids || props.kind !== 'citation_id') return false
   return ids.some((id) => id.toLowerCase() === props.term.toLowerCase())
@@ -52,28 +69,39 @@ const isIdActive = (ids: string[] | undefined) => {
 <template>
   <div>
     <p class="mb-4" v-if="!isLoading && !error">
-      <template v-if="!hasResults && !term.trim() && !query?.trim()">
+      <template v-if="!hasResults && !hasActiveSearch">
         Perform a search to see results.
       </template>
-      <template v-else-if="!hasResults && query?.trim()">
-        No results for <strong>"{{ query }}"</strong>
-      </template>
       <template v-else-if="!hasResults">
-        No results for <strong>"{{ term }}"</strong> in <strong>{{ kindLabel }}</strong>
-      </template>
-      <template v-else-if="query?.trim()">
-        <template v-if="resultsCount === 1">
-          <strong>1 result</strong> for <strong>"{{ query }}"</strong>
+        No results for
+        <template v-if="query?.trim()"><strong>"{{ query }}"</strong></template>
+        <template v-if="query?.trim() && groupedFilters.length"> with </template>
+        <template v-for="(group, gi) in groupedFilters" :key="group.kind">
+          <strong>{{ SEARCH_KIND_LABEL_MAP[group.kind] || group.kind }}</strong>:
+          <template v-for="(term, ti) in group.terms" :key="term">
+            "<strong>{{ term }}</strong>"
+            <template v-if="ti < group.terms.length - 2">, </template>
+            <template v-else-if="ti === group.terms.length - 2"> and </template>
+          </template>
+          <template v-if="gi < groupedFilters.length - 2">, </template>
+          <template v-else-if="gi === groupedFilters.length - 2"> and </template>
         </template>
-        <template v-else>
-          <strong>{{ formatNumber(resultsCount) }} results</strong> for <strong>"{{ query }}"</strong>
-        </template>
-      </template>
-      <template v-else-if="resultsCount === 1">
-        <strong>1 result</strong> for <strong>"{{ term }}"</strong> in <strong>{{ kindLabel }}</strong>
       </template>
       <template v-else>
-        <strong>{{ formatNumber(resultsCount) }} results</strong> for <strong>"{{ term }}"</strong> in <strong>{{ kindLabel }}</strong>
+        <strong>{{ resultsCount === 1 ? '1 result' : `${formatNumber(resultsCount)} results` }}</strong>
+        <template v-if="query?.trim()"> for <strong>"{{ query }}"</strong></template>
+        <template v-if="query?.trim() && groupedFilters.length"> with </template>
+        <template v-else-if="!query?.trim() && groupedFilters.length"> for </template>
+        <template v-for="(group, gi) in groupedFilters" :key="group.kind">
+          <strong>{{ SEARCH_KIND_LABEL_MAP[group.kind] || group.kind }}</strong>:
+          <template v-for="(term, ti) in group.terms" :key="term">
+            "<strong>{{ term }}</strong>"
+            <template v-if="ti < group.terms.length - 2">, </template>
+            <template v-else-if="ti === group.terms.length - 2"> and </template>
+          </template>
+          <template v-if="gi < groupedFilters.length - 2">, </template>
+          <template v-else-if="gi === groupedFilters.length - 2"> and </template>
+        </template>
       </template>
     </p>
 

--- a/src/components/molecules/SearchResults.vue
+++ b/src/components/molecules/SearchResults.vue
@@ -17,6 +17,7 @@ interface Props {
   error: string | null
   term: string
   kind: string
+  query?: string
 }
 
 const props = defineProps<Props>()
@@ -51,11 +52,22 @@ const isIdActive = (ids: string[] | undefined) => {
 <template>
   <div>
     <p class="mb-4" v-if="!isLoading && !error">
-      <template v-if="!hasResults && term.trim() === ''">
+      <template v-if="!hasResults && !term.trim() && !query?.trim()">
         Perform a search to see results.
+      </template>
+      <template v-else-if="!hasResults && query?.trim()">
+        No results for <strong>"{{ query }}"</strong>
       </template>
       <template v-else-if="!hasResults">
         No results for <strong>"{{ term }}"</strong> in <strong>{{ kindLabel }}</strong>
+      </template>
+      <template v-else-if="query?.trim()">
+        <template v-if="resultsCount === 1">
+          <strong>1 result</strong> for <strong>"{{ query }}"</strong>
+        </template>
+        <template v-else>
+          <strong>{{ formatNumber(resultsCount) }} results</strong> for <strong>"{{ query }}"</strong>
+        </template>
       </template>
       <template v-else-if="resultsCount === 1">
         <strong>1 result</strong> for <strong>"{{ term }}"</strong> in <strong>{{ kindLabel }}</strong>

--- a/src/components/molecules/SearchResults.vue
+++ b/src/components/molecules/SearchResults.vue
@@ -88,7 +88,7 @@ const isIdActive = (ids: string[] | undefined) => {
         <ListItem
           v-for="item in results"
           :key="item.resource_path"
-          :title="item.data.description?.[0] || item.resource_path"
+          :title="item.data._title?.[0] || item.data.description?.[0] || item.resource_path"
           :link="item.data.aliased_uri?.[0] || ''"
         >
           <div class="text-gray-600 dark:text-gray-400">

--- a/src/components/molecules/SearchResults.vue
+++ b/src/components/molecules/SearchResults.vue
@@ -5,7 +5,7 @@ import TermButton from '@/components/atoms/TermButton.vue'
 import FileIcon from '@/components/icons/FileIcon.vue'
 import ListContent from '@/components/molecules/ListContent.vue'
 import ListItem from '@/components/molecules/ListItem.vue'
-import { SEARCH_KIND_LABEL_MAP } from '@/constants/search'
+import { SEARCH_KIND_LABEL_MAP, SEARCH_KIND_LABEL_SINGULAR_MAP } from '@/constants/search'
 import type { SearchFilter, SearchResult } from '@/types/search'
 import { getExposureIdFromResourcePath } from '@/utils/exposure'
 import { formatDate, formatNumber } from '@/utils/format'
@@ -77,7 +77,7 @@ const isIdActive = (ids: string[] | undefined) => {
         <template v-if="query?.trim()"><strong>"{{ query }}"</strong></template>
         <template v-if="query?.trim() && groupedFilters.length"> with </template>
         <template v-for="(group, gi) in groupedFilters" :key="group.kind">
-          <strong>{{ SEARCH_KIND_LABEL_MAP[group.kind] || group.kind }}</strong>:
+          <strong>{{ group.terms.length === 1 ? (SEARCH_KIND_LABEL_SINGULAR_MAP[group.kind] || group.kind) : (SEARCH_KIND_LABEL_MAP[group.kind] || group.kind) }}</strong>:
           <template v-for="(term, ti) in group.terms" :key="term">
             "<strong>{{ term }}</strong>"
             <template v-if="ti < group.terms.length - 2">, </template>
@@ -93,7 +93,7 @@ const isIdActive = (ids: string[] | undefined) => {
         <template v-if="query?.trim() && groupedFilters.length"> with </template>
         <template v-else-if="!query?.trim() && groupedFilters.length"> for </template>
         <template v-for="(group, gi) in groupedFilters" :key="group.kind">
-          <strong>{{ SEARCH_KIND_LABEL_MAP[group.kind] || group.kind }}</strong>:
+          <strong>{{ group.terms.length === 1 ? (SEARCH_KIND_LABEL_SINGULAR_MAP[group.kind] || group.kind) : (SEARCH_KIND_LABEL_MAP[group.kind] || group.kind) }}</strong>:
           <template v-for="(term, ti) in group.terms" :key="term">
             "<strong>{{ term }}</strong>"
             <template v-if="ti < group.terms.length - 2">, </template>

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -826,7 +826,7 @@ onMounted(async () => {
         </ul>
         <div v-if="hasOtherRelatedModels" class="mb-4">
           <RouterLink
-            :to="`/search?kind=citation_id&term=${metadataJSON.citation_id}`"
+            :to="{ path: '/search', query: { citation_id: metadataJSON.citation_id } }"
             class="text-link text-sm inline-flex items-center gap-2 break-all"
           >
             <span class="text-foreground">›</span>

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -99,9 +99,12 @@ onMounted(async () => {
 })
 
 // Watch for route param changes to reload results.
-watch(() => route.query, async () => {
-  await loadResults()
-})
+watch(
+  () => route.query,
+  async () => {
+    await loadResults()
+  },
+)
 
 const loadResults = async (forceRefresh = false) => {
   const hasQuery = !!searchQueryParam.value

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -25,6 +25,7 @@ const globalState = useGlobalStateStore()
 
 const kind = computed(() => (route.query.kind as string) || '')
 const term = computed(() => (route.query.term as string) || '')
+const searchQueryParam = computed(() => (route.query.query as string) || '')
 const searchResults = ref<SearchResult[]>([])
 const isLoading = ref(false)
 const resultsError = ref<string | null>(null)
@@ -58,11 +59,15 @@ watch(
 
 // Sync sort with URL query parameters whilst preserving the kind and term params.
 watch(sortBy, (newSort) => {
-  const query: Record<string, string> = {}
-  if (kind.value) query.kind = kind.value
-  if (term.value) query.term = term.value
-  if (newSort !== DEFAULT_SORT_OPTION) query.sort = newSort
-  router.replace({ query })
+  const nextQuery: Record<string, string> = {}
+  if (searchQueryParam.value) {
+    nextQuery.query = searchQueryParam.value
+  } else {
+    if (kind.value) nextQuery.kind = kind.value
+    if (term.value) nextQuery.term = term.value
+  }
+  if (newSort !== DEFAULT_SORT_OPTION) nextQuery.sort = newSort
+  router.replace({ query: nextQuery })
 })
 
 onMounted(async () => {
@@ -70,11 +75,28 @@ onMounted(async () => {
 })
 
 // Watch for route param changes to reload results.
-watch([kind, term], async () => {
+watch([kind, term, searchQueryParam], async () => {
   await loadResults()
 })
 
 const loadResults = async (forceRefresh = false) => {
+  if (searchQueryParam.value) {
+    isLoading.value = true
+    resultsError.value = null
+    searchResults.value = []
+
+    try {
+      searchResults.value = await searchStore.searchQuery(searchQueryParam.value, forceRefresh)
+    } catch (err) {
+      resultsError.value = err instanceof Error ? err.message : 'Failed to load search results'
+      console.error('Failed to load search results by query:', err)
+    } finally {
+      isLoading.value = false
+    }
+
+    return
+  }
+
   if (!kind.value || !term.value) {
     // If no search parameters are provided, do not redirect.
     // Simply return without loading results to avoid confusing UX.

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -123,6 +123,12 @@ const handleSearch = (searchKind: string, searchTerm: string) => {
   router.push({ path: '/search', query })
 }
 
+const handleQuerySearch = (query: string) => {
+  const searchQuery: Record<string, string> = { query }
+  if (sortBy.value !== DEFAULT_SORT_OPTION) searchQuery.sort = sortBy.value
+  router.push({ path: '/search', query: searchQuery })
+}
+
 const sortedResults = computed(() => sortSearchResults(searchResults.value, sortBy.value))
 
 const hasResults = computed(() => searchResults.value.length > 0)
@@ -140,6 +146,7 @@ const handleRefresh = async () => {
       :initial-kind="kind"
       :initial-term="searchQueryParam || term"
       @search="handleSearch"
+      @querySearch="handleQuerySearch"
     />
     <SortDropdown
       v-if="hasResults || isLoading"

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -189,6 +189,7 @@ const handleRefresh = async () => {
         :term="term"
         :kind="kind"
         :query="searchQueryParam"
+        :filters="queryFilters"
       />
     </main>
   </div>

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -92,7 +92,7 @@ const loadResults = async (forceRefresh = false) => {
               query: searchQueryParam.value,
               filters: [{ kind: kind.value, term: term.value }],
             }
-          : searchQueryParam.value,
+          : { query: searchQueryParam.value },
         forceRefresh,
       )
     } catch (err) {

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -7,11 +7,11 @@ import RefreshIcon from '@/components/icons/RefreshIcon.vue'
 import SearchInput from '@/components/molecules/SearchInput.vue'
 import SearchResults from '@/components/molecules/SearchResults.vue'
 import SortDropdown from '@/components/molecules/SortDropdown.vue'
+import { SEARCH_KIND_NAMES } from '@/constants/search'
 import { useGlobalStateStore } from '@/stores/globalState'
 import { useSearchStore } from '@/stores/search'
 import type { SortOption } from '@/types/common'
 import type { SearchResult } from '@/types/search'
-import { SEARCH_KIND_NAMES } from '@/constants/search'
 import { parseIndexFilterFromQuery, parseQueryFiltersFromQuery } from '@/utils/search'
 import {
   DEFAULT_SORT_OPTION,

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -11,6 +11,8 @@ import { useGlobalStateStore } from '@/stores/globalState'
 import { useSearchStore } from '@/stores/search'
 import type { SortOption } from '@/types/common'
 import type { SearchResult } from '@/types/search'
+import { SEARCH_KIND_NAMES } from '@/constants/search'
+import { parseIndexFilterFromQuery, parseQueryFiltersFromQuery } from '@/utils/search'
 import {
   DEFAULT_SORT_OPTION,
   isValidSortOption,
@@ -23,9 +25,18 @@ const router = useRouter()
 const searchStore = useSearchStore()
 const globalState = useGlobalStateStore()
 
-const kind = computed(() => (route.query.kind as string) || '')
-const term = computed(() => (route.query.term as string) || '')
-const searchQueryParam = computed(() => (route.query.query as string) || '')
+const indexFilter = computed(() => parseIndexFilterFromQuery(route.query))
+const queryFilters = computed(() => parseQueryFiltersFromQuery(route.query, SEARCH_KIND_NAMES))
+const kind = computed(() => indexFilter.value?.kind || '')
+const term = computed(() => indexFilter.value?.term || '')
+const searchQueryParam = computed(() => {
+  const query = route.query.query
+  if (Array.isArray(query)) {
+    return typeof query[0] === 'string' ? query[0] : ''
+  }
+
+  return typeof query === 'string' ? query : ''
+})
 const searchResults = ref<SearchResult[]>([])
 const isLoading = ref(false)
 const resultsError = ref<string | null>(null)
@@ -57,12 +68,28 @@ watch(
   },
 )
 
-// Sync sort with URL query parameters whilst preserving the kind and term params.
+// Sync sort with URL query parameters whilst preserving the current search params.
 watch(sortBy, (newSort) => {
-  const nextQuery: Record<string, string> = {}
+  const nextQuery: Record<string, string | string[]> = {}
+
   if (searchQueryParam.value) nextQuery.query = searchQueryParam.value
-  if (kind.value) nextQuery.kind = kind.value
-  if (term.value) nextQuery.term = term.value
+
+  if (indexFilter.value) {
+    nextQuery.kind = indexFilter.value.kind
+    nextQuery.term = indexFilter.value.term
+  }
+
+  for (const filter of queryFilters.value) {
+    const existing = nextQuery[filter.kind]
+    if (existing === undefined) {
+      nextQuery[filter.kind] = filter.term
+    } else if (Array.isArray(existing)) {
+      existing.push(filter.term)
+    } else {
+      nextQuery[filter.kind] = [existing, filter.term]
+    }
+  }
+
   if (newSort !== DEFAULT_SORT_OPTION) nextQuery.sort = newSort
   router.replace({ query: nextQuery })
 })
@@ -72,17 +99,17 @@ onMounted(async () => {
 })
 
 // Watch for route param changes to reload results.
-watch([kind, term, searchQueryParam], async () => {
+watch(() => route.query, async () => {
   await loadResults()
 })
 
 const loadResults = async (forceRefresh = false) => {
   const hasQuery = !!searchQueryParam.value
-  const hasFilter = !!kind.value && !!term.value
+  const hasIndexFilter = !!indexFilter.value
+  const hasQueryFilters = queryFilters.value.length > 0
 
-  if (!hasFilter) {
-    // If no search parameters are provided, do not redirect.
-    // Simply return without loading results to avoid confusing UX.
+  if (!hasQuery && !hasIndexFilter && !hasQueryFilters) {
+    // If no search parameters are provided, simply return to avoid an empty search.
     return
   }
 
@@ -90,15 +117,13 @@ const loadResults = async (forceRefresh = false) => {
   resultsError.value = null
   searchResults.value = []
 
-  if (hasQuery) {
+  if (hasQuery || hasQueryFilters) {
     try {
       searchResults.value = await searchStore.searchQuery(
-        hasFilter
-          ? {
-              query: searchQueryParam.value,
-              filters: [{ kind: kind.value, term: term.value }],
-            }
-          : { query: searchQueryParam.value },
+        {
+          query: searchQueryParam.value || undefined,
+          filters: queryFilters.value,
+        },
         forceRefresh,
       )
     } catch (err) {
@@ -112,7 +137,11 @@ const loadResults = async (forceRefresh = false) => {
   }
 
   try {
-    searchResults.value = await searchStore.searchIndexTerm(kind.value, term.value, forceRefresh)
+    searchResults.value = await searchStore.searchIndexTerm(
+      indexFilter.value!.kind,
+      indexFilter.value!.term,
+      forceRefresh,
+    )
   } catch (err) {
     resultsError.value = err instanceof Error ? err.message : 'Failed to load search results'
     console.error('Failed to load search results:', err)

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -60,12 +60,9 @@ watch(
 // Sync sort with URL query parameters whilst preserving the kind and term params.
 watch(sortBy, (newSort) => {
   const nextQuery: Record<string, string> = {}
-  if (searchQueryParam.value) {
-    nextQuery.query = searchQueryParam.value
-  } else {
-    if (kind.value) nextQuery.kind = kind.value
-    if (term.value) nextQuery.term = term.value
-  }
+  if (searchQueryParam.value) nextQuery.query = searchQueryParam.value
+  if (kind.value) nextQuery.kind = kind.value
+  if (term.value) nextQuery.term = term.value
   if (newSort !== DEFAULT_SORT_OPTION) nextQuery.sort = newSort
   router.replace({ query: nextQuery })
 })
@@ -80,13 +77,24 @@ watch([kind, term, searchQueryParam], async () => {
 })
 
 const loadResults = async (forceRefresh = false) => {
-  if (searchQueryParam.value) {
-    isLoading.value = true
-    resultsError.value = null
-    searchResults.value = []
+  const hasQuery = !!searchQueryParam.value
+  const hasFilter = !!kind.value && !!term.value
 
+  isLoading.value = true
+  resultsError.value = null
+  searchResults.value = []
+
+  if (hasQuery) {
     try {
-      searchResults.value = await searchStore.searchQuery(searchQueryParam.value, forceRefresh)
+      searchResults.value = await searchStore.searchQuery(
+        hasFilter
+          ? {
+              query: searchQueryParam.value,
+              filters: [{ kind: kind.value, term: term.value }],
+            }
+          : searchQueryParam.value,
+        forceRefresh,
+      )
     } catch (err) {
       resultsError.value = err instanceof Error ? err.message : 'Failed to load search results'
       console.error('Failed to load search results by query:', err)
@@ -97,15 +105,11 @@ const loadResults = async (forceRefresh = false) => {
     return
   }
 
-  if (!kind.value || !term.value) {
+  if (!hasFilter) {
     // If no search parameters are provided, do not redirect.
     // Simply return without loading results to avoid confusing UX.
     return
   }
-
-  isLoading.value = true
-  resultsError.value = null
-  searchResults.value = []
 
   try {
     searchResults.value = await searchStore.searchIndexTerm(kind.value, term.value, forceRefresh)

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -80,6 +80,12 @@ const loadResults = async (forceRefresh = false) => {
   const hasQuery = !!searchQueryParam.value
   const hasFilter = !!kind.value && !!term.value
 
+  if (!hasFilter) {
+    // If no search parameters are provided, do not redirect.
+    // Simply return without loading results to avoid confusing UX.
+    return
+  }
+
   isLoading.value = true
   resultsError.value = null
   searchResults.value = []
@@ -102,12 +108,6 @@ const loadResults = async (forceRefresh = false) => {
       isLoading.value = false
     }
 
-    return
-  }
-
-  if (!hasFilter) {
-    // If no search parameters are provided, do not redirect.
-    // Simply return without loading results to avoid confusing UX.
     return
   }
 

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -167,6 +167,7 @@ const handleRefresh = async () => {
         :error="resultsError"
         :term="term"
         :kind="kind"
+        :query="searchQueryParam"
       />
     </main>
   </div>

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -12,7 +12,7 @@ import { useGlobalStateStore } from '@/stores/globalState'
 import { useSearchStore } from '@/stores/search'
 import type { SortOption } from '@/types/common'
 import type { SearchResult } from '@/types/search'
-import { parseIndexFilterFromQuery, parseQueryFiltersFromQuery } from '@/utils/search'
+import { buildQuerySearchQuery, parseQueryFiltersFromQuery } from '@/utils/search'
 import {
   DEFAULT_SORT_OPTION,
   isValidSortOption,
@@ -25,10 +25,10 @@ const router = useRouter()
 const searchStore = useSearchStore()
 const globalState = useGlobalStateStore()
 
-const indexFilter = computed(() => parseIndexFilterFromQuery(route.query))
 const queryFilters = computed(() => parseQueryFiltersFromQuery(route.query, SEARCH_KIND_NAMES))
-const kind = computed(() => indexFilter.value?.kind || '')
-const term = computed(() => indexFilter.value?.term || '')
+const activeFilter = computed(() => queryFilters.value[0] ?? null)
+const kind = computed(() => activeFilter.value?.kind || '')
+const term = computed(() => activeFilter.value?.term || '')
 const searchQueryParam = computed(() => {
   const query = route.query.query
   if (Array.isArray(query)) {
@@ -74,11 +74,6 @@ watch(sortBy, (newSort) => {
 
   if (searchQueryParam.value) nextQuery.query = searchQueryParam.value
 
-  if (indexFilter.value) {
-    nextQuery.kind = indexFilter.value.kind
-    nextQuery.term = indexFilter.value.term
-  }
-
   for (const filter of queryFilters.value) {
     const existing = nextQuery[filter.kind]
     if (existing === undefined) {
@@ -108,10 +103,9 @@ watch(
 
 const loadResults = async (forceRefresh = false) => {
   const hasQuery = !!searchQueryParam.value
-  const hasIndexFilter = !!indexFilter.value
   const hasQueryFilters = queryFilters.value.length > 0
 
-  if (!hasQuery && !hasIndexFilter && !hasQueryFilters) {
+  if (!hasQuery && !hasQueryFilters) {
     // If no search parameters are provided, simply return to avoid an empty search.
     return
   }
@@ -120,43 +114,27 @@ const loadResults = async (forceRefresh = false) => {
   resultsError.value = null
   searchResults.value = []
 
-  if (hasQuery || hasQueryFilters) {
-    try {
-      searchResults.value = await searchStore.searchQuery(
-        {
-          query: searchQueryParam.value || undefined,
-          filters: queryFilters.value,
-        },
-        forceRefresh,
-      )
-    } catch (err) {
-      resultsError.value = err instanceof Error ? err.message : 'Failed to load search results'
-      console.error('Failed to load search results by query:', err)
-    } finally {
-      isLoading.value = false
-    }
-
-    return
-  }
-
   try {
-    searchResults.value = await searchStore.searchIndexTerm(
-      indexFilter.value!.kind,
-      indexFilter.value!.term,
+    searchResults.value = await searchStore.searchQuery(
+      {
+        query: searchQueryParam.value || undefined,
+        filters: queryFilters.value,
+      },
       forceRefresh,
     )
   } catch (err) {
     resultsError.value = err instanceof Error ? err.message : 'Failed to load search results'
-    console.error('Failed to load search results:', err)
+    console.error('Failed to load search results by query:', err)
   } finally {
     isLoading.value = false
   }
 }
 
 const handleSearch = (searchKind: string, searchTerm: string) => {
-  const query: Record<string, string> = { kind: searchKind, term: searchTerm }
-  if (sortBy.value !== DEFAULT_SORT_OPTION) query.sort = sortBy.value
-  router.push({ path: '/search', query })
+  router.push({
+    path: '/search',
+    query: buildQuerySearchQuery('', [{ kind: searchKind, term: searchTerm }], route.query),
+  })
 }
 
 const handleQuerySearch = (query: string) => {

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -138,7 +138,7 @@ const handleRefresh = async () => {
       class="flex-1 w-full sm:w-auto"
       ref="searchInputRef"
       :initial-kind="kind"
-      :initial-term="term"
+      :initial-term="searchQueryParam || term"
       @search="handleSearch"
     />
     <SortDropdown

--- a/src/components/organisms/SearchOverlay.vue
+++ b/src/components/organisms/SearchOverlay.vue
@@ -3,7 +3,7 @@ import { nextTick, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import CloseButton from '@/components/atoms/CloseButton.vue'
 import SearchInput from '@/components/molecules/SearchInput.vue'
-import { buildSearchQuery } from '@/utils/search'
+import { buildQuerySearchQuery, buildSearchQuery } from '@/utils/search'
 
 const props = defineProps<{
   show: boolean
@@ -60,7 +60,7 @@ const handleSearch = (searchKind: string, searchTerm: string) => {
 }
 
 const handleQuerySearch = (query: string) => {
-  router.push({ path: '/search', query: { query } })
+  router.push({ path: '/search', query: buildQuerySearchQuery(query, route.query) })
   emit('close')
 }
 

--- a/src/components/organisms/SearchOverlay.vue
+++ b/src/components/organisms/SearchOverlay.vue
@@ -60,7 +60,7 @@ const handleSearch = (searchKind: string, searchTerm: string) => {
 }
 
 const handleQuerySearch = (query: string) => {
-  router.push({ path: '/search', query: buildQuerySearchQuery(query, route.query) })
+  router.push({ path: '/search', query: buildQuerySearchQuery(query, [], route.query) })
   emit('close')
 }
 

--- a/src/components/organisms/SearchOverlay.vue
+++ b/src/components/organisms/SearchOverlay.vue
@@ -103,8 +103,7 @@ const getInitialKind = (): string => {
         <CloseButton @click="emit('close')" />
       </div>
       <div class="my-4 text-sm text-gray-500 dark:text-gray-400">
-        Search by author, CellML keyword, publication, or free text.
-        Type to see suggestions or press <Keycap>Enter</Keycap> to search.
+        Search by author, keyword, publication reference, or free text.
       </div>
       <div class="pb-4">
         <SearchInput

--- a/src/components/organisms/SearchOverlay.vue
+++ b/src/components/organisms/SearchOverlay.vue
@@ -3,7 +3,8 @@ import { nextTick, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import CloseButton from '@/components/atoms/CloseButton.vue'
 import SearchInput from '@/components/molecules/SearchInput.vue'
-import { buildQuerySearchQuery, buildSearchQuery } from '@/utils/search'
+import { SEARCH_KIND_NAMES } from '@/constants/search'
+import { buildQuerySearchQuery, buildSearchQuery, parseQueryFiltersFromQuery } from '@/utils/search'
 
 const props = defineProps<{
   show: boolean
@@ -66,22 +67,25 @@ const handleQuerySearch = (query: string) => {
 
 const getInitialTerm = (): string => {
   const filterQuery = route.query.filter
-  const termQuery = route.query.term
+  const queryParam = route.query.query
 
   if (typeof filterQuery === 'string') {
     return filterQuery
   }
 
-  if (typeof termQuery === 'string') {
-    return termQuery
+  if (typeof queryParam === 'string') {
+    return queryParam
   }
+
+  const firstFilter = parseQueryFiltersFromQuery(route.query, SEARCH_KIND_NAMES)[0]
+  if (firstFilter) return firstFilter.term
 
   return ''
 }
 
 const getInitialKind = (): string => {
-  const kindQuery = route.query.kind
-  return typeof kindQuery === 'string' ? kindQuery : ''
+  const firstFilter = parseQueryFiltersFromQuery(route.query, SEARCH_KIND_NAMES)[0]
+  return firstFilter?.kind ?? ''
 }
 </script>
 

--- a/src/components/organisms/SearchOverlay.vue
+++ b/src/components/organisms/SearchOverlay.vue
@@ -2,6 +2,7 @@
 import { nextTick, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import CloseButton from '@/components/atoms/CloseButton.vue'
+import Keycap from '@/components/atoms/Keycap.vue'
 import SearchInput from '@/components/molecules/SearchInput.vue'
 import { SEARCH_KIND_NAMES } from '@/constants/search'
 import { buildQuerySearchQuery, buildSearchQuery, parseQueryFiltersFromQuery } from '@/utils/search'
@@ -103,7 +104,7 @@ const getInitialKind = (): string => {
       </div>
       <div class="my-4 text-sm text-gray-500 dark:text-gray-400">
         Search by author, CellML keyword, publication, or free text.
-        Type to see suggestions or press <em>Enter</em> to search.
+        Type to see suggestions or press <Keycap>Enter</Keycap> to search.
       </div>
       <div class="pb-4">
         <SearchInput

--- a/src/components/organisms/SearchOverlay.vue
+++ b/src/components/organisms/SearchOverlay.vue
@@ -59,6 +59,11 @@ const handleSearch = (searchKind: string, searchTerm: string) => {
   emit('close')
 }
 
+const handleQuerySearch = (query: string) => {
+  router.push({ path: '/search', query: { query } })
+  emit('close')
+}
+
 const getInitialTerm = (): string => {
   const filterQuery = route.query.filter
   const termQuery = route.query.term
@@ -105,6 +110,7 @@ const getInitialKind = (): string => {
           :initial-kind="getInitialKind()"
           :initial-term="getInitialTerm()"
           @search="handleSearch"
+          @querySearch="handleQuerySearch"
           @close="emit('close')"
         />
       </div>

--- a/src/components/organisms/SearchOverlay.vue
+++ b/src/components/organisms/SearchOverlay.vue
@@ -97,7 +97,7 @@ const getInitialKind = (): string => {
         <h2 class="text-lg font-semibold">Search</h2>
         <CloseButton @click="emit('close')" />
       </div>
-      <div class="my-4 text-sm text-gray-400 dark:text-gray-400">
+      <div class="my-4 text-sm text-gray-500 dark:text-gray-400">
         Search by author, CellML keyword, publication, or free text.
         Type to see suggestions or press <em>Enter</em> to search.
       </div>

--- a/src/components/organisms/SearchOverlay.vue
+++ b/src/components/organisms/SearchOverlay.vue
@@ -97,13 +97,11 @@ const getInitialKind = (): string => {
         <h2 class="text-lg font-semibold">Search</h2>
         <CloseButton @click="emit('close')" />
       </div>
-      <div class="my-4 text-sm text-gray-500 dark:text-gray-400">
-        <p class="lg:w-3/4">
-          Search for models across authors, CellML keywords, and publication references.
-          Start typing to see available terms grouped by category.
-        </p>
+      <div class="my-4 text-sm text-gray-400 dark:text-gray-400">
+        Search by author, CellML keyword, publication, or free text.
+        Type to see suggestions or press <em>Enter</em> to search.
       </div>
-      <div class="py-4">
+      <div class="pb-4">
         <SearchInput
           ref="searchInputRef"
           :inOverlay="true"

--- a/src/constants/search.ts
+++ b/src/constants/search.ts
@@ -1,5 +1,9 @@
 export const SEARCH_CATEGORIES = [
-  { value: 'citation_author_family_name', label: 'Publication authors', labelSingular: 'Publication author' },
+  {
+    value: 'citation_author_family_name',
+    label: 'Publication authors',
+    labelSingular: 'Publication author',
+  },
   { value: 'model_author', label: 'Model authors', labelSingular: 'Model author' },
   { value: 'cellml_keyword', label: 'CellML keywords', labelSingular: 'CellML keyword' },
   { value: 'citation_id', label: 'Publication references', labelSingular: 'Publication reference' },

--- a/src/constants/search.ts
+++ b/src/constants/search.ts
@@ -1,12 +1,16 @@
 export const SEARCH_CATEGORIES = [
-  { value: 'citation_author_family_name', label: 'Publication authors' },
-  { value: 'model_author', label: 'Model authors' },
-  { value: 'cellml_keyword', label: 'CellML keywords' },
-  { value: 'citation_id', label: 'Publication references' },
+  { value: 'citation_author_family_name', label: 'Publication authors', labelSingular: 'Publication author' },
+  { value: 'model_author', label: 'Model authors', labelSingular: 'Model author' },
+  { value: 'cellml_keyword', label: 'CellML keywords', labelSingular: 'CellML keyword' },
+  { value: 'citation_id', label: 'Publication references', labelSingular: 'Publication reference' },
 ] as const
 
 export const SEARCH_KIND_LABEL_MAP: Record<string, string> = Object.fromEntries(
   SEARCH_CATEGORIES.map((cat) => [cat.value, cat.label]),
+)
+
+export const SEARCH_KIND_LABEL_SINGULAR_MAP: Record<string, string> = Object.fromEntries(
+  SEARCH_CATEGORIES.map((cat) => [cat.value, cat.labelSingular]),
 )
 
 export const SEARCH_KIND_NAMES = SEARCH_CATEGORIES.map((c) => c.value) as readonly string[]

--- a/src/constants/search.ts
+++ b/src/constants/search.ts
@@ -8,3 +8,5 @@ export const SEARCH_CATEGORIES = [
 export const SEARCH_KIND_LABEL_MAP: Record<string, string> = Object.fromEntries(
   SEARCH_CATEGORIES.map((cat) => [cat.value, cat.label]),
 )
+
+export const SEARCH_KIND_NAMES = SEARCH_CATEGORIES.map((c) => c.value) as readonly string[]

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -2,6 +2,7 @@ import type {
   IndexesResponse,
   IndexKindResponse,
   IndexSearchResult,
+  SearchQueryRequest,
   SearchQueryResponse,
 } from '@/types/search'
 
@@ -56,13 +57,16 @@ export const searchService = {
     return await response.json()
   },
 
-  async searchQuery(query: string): Promise<SearchQueryResponse> {
+  async searchQuery(search: string | SearchQueryRequest): Promise<SearchQueryResponse> {
+    const payload: SearchQueryRequest =
+      typeof search === 'string' ? { query: search } : { query: search.query, filters: search.filters }
+
     const response = await fetch(`${API_BASE_URL}/api/search`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ query }),
+      body: JSON.stringify(payload),
     })
 
     if (!response.ok) {

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -1,4 +1,9 @@
-import type { IndexesResponse, IndexKindResponse, IndexSearchResult } from '@/types/search'
+import type {
+  IndexesResponse,
+  IndexKindResponse,
+  IndexSearchResult,
+  SearchQueryResponse,
+} from '@/types/search'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL
 
@@ -51,7 +56,7 @@ export const searchService = {
     return await response.json()
   },
 
-  async searchQuery(query: string): Promise<unknown> {
+  async searchQuery(query: string): Promise<SearchQueryResponse> {
     const response = await fetch(`${API_BASE_URL}/api/search`, {
       method: 'POST',
       headers: {

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -57,10 +57,7 @@ export const searchService = {
     return await response.json()
   },
 
-  async searchQuery(search: string | SearchQueryRequest): Promise<SearchQueryResponse> {
-    const payload: SearchQueryRequest =
-      typeof search === 'string' ? { query: search } : { query: search.query, filters: search.filters }
-
+  async searchQuery(payload: SearchQueryRequest): Promise<SearchQueryResponse> {
     const response = await fetch(`${API_BASE_URL}/api/search`, {
       method: 'POST',
       headers: {

--- a/src/services/searchService.ts
+++ b/src/services/searchService.ts
@@ -50,4 +50,20 @@ export const searchService = {
 
     return await response.json()
   },
+
+  async searchQuery(query: string): Promise<unknown> {
+    const response = await fetch(`${API_BASE_URL}/api/search`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query }),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Request failed: ${response.status}`)
+    }
+
+    return await response.json()
+  },
 }

--- a/src/stores/search.test.ts
+++ b/src/stores/search.test.ts
@@ -64,6 +64,25 @@ describe('useSearchStore searchQuery', () => {
     expect(response).toEqual(results)
   })
 
+  it('trims query and filter values before calling the service', async () => {
+    const store = useSearchStore()
+    const payload: SearchQueryRequest = {
+      query: '  combined query  ',
+      filters: [{ kind: '  cellml_keyword  ', term: '  action-potential  ' }],
+    }
+    const results = [buildResult('/r/trimmed')]
+    mockSearchQuery.mockResolvedValue({ results })
+
+    const response = await store.searchQuery(payload)
+
+    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
+    expect(mockSearchQuery).toHaveBeenCalledWith({
+      query: 'combined query',
+      filters: [{ kind: 'cellml_keyword', term: 'action-potential' }],
+    })
+    expect(response).toEqual(results)
+  })
+
   it('supports filters-only payloads', async () => {
     const store = useSearchStore()
     const payload: SearchQueryRequest = {
@@ -167,5 +186,28 @@ describe('useSearchStore searchQuery', () => {
     expect(mockSearchQuery).toHaveBeenCalledTimes(2)
     expect(mockSearchQuery).toHaveBeenNthCalledWith(1, payloadA)
     expect(mockSearchQuery).toHaveBeenNthCalledWith(2, payloadB)
+  })
+
+  it('reuses the cache for semantically identical trimmed searches', async () => {
+    const store = useSearchStore()
+    const results = [buildResult('/r/trimmed-cache')]
+    mockSearchQuery.mockResolvedValue({ results })
+
+    const paddedPayload: SearchQueryRequest = {
+      query: '  same query  ',
+      filters: [{ kind: '  cellml_keyword  ', term: '  a  ' }],
+    }
+    const trimmedPayload: SearchQueryRequest = {
+      query: 'same query',
+      filters: [{ kind: 'cellml_keyword', term: 'a' }],
+    }
+
+    const first = await store.searchQuery(paddedPayload)
+    const second = await store.searchQuery(trimmedPayload)
+
+    expect(first).toEqual(results)
+    expect(second).toEqual(results)
+    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
+    expect(mockSearchQuery).toHaveBeenCalledWith(trimmedPayload)
   })
 })

--- a/src/stores/search.test.ts
+++ b/src/stores/search.test.ts
@@ -1,0 +1,111 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SearchQueryRequest, SearchResult } from '@/types/search'
+
+const { mockSearchQuery } = vi.hoisted(() => ({
+  mockSearchQuery: vi.fn<(search: SearchQueryRequest) => Promise<{ results: SearchResult[] }>>(),
+}))
+
+vi.mock('@/services', () => ({
+  getSearchService: () => ({
+    searchQuery: mockSearchQuery,
+  }),
+}))
+
+import { useSearchStore } from './search'
+
+const buildResult = (resourcePath: string): SearchResult => ({
+  resource_path: resourcePath,
+  data: {
+    aliased_uri: [],
+    cellml_keyword: [],
+    commit_authored_ts: [],
+    created_ts: [],
+    description: [],
+    exposure_alias: [],
+    citation_author_family_name: [],
+    citation_id: [],
+    model_author: [],
+  },
+})
+
+describe('useSearchStore searchQuery', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    mockSearchQuery.mockReset()
+  })
+
+  it('normalizes legacy string input to request payload', async () => {
+    const store = useSearchStore()
+    const results = [buildResult('/r/legacy')]
+    mockSearchQuery.mockResolvedValue({ results })
+
+    const response = await store.searchQuery('legacy query')
+
+    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
+    expect(mockSearchQuery).toHaveBeenCalledWith({ query: 'legacy query' })
+    expect(response).toEqual(results)
+  })
+
+  it('passes query+filters payload through to the service', async () => {
+    const store = useSearchStore()
+    const payload: SearchQueryRequest = {
+      query: 'combined query',
+      filters: [{ kind: 'cellml_keyword', term: 'action-potential' }],
+    }
+    const results = [buildResult('/r/combined')]
+    mockSearchQuery.mockResolvedValue({ results })
+
+    const response = await store.searchQuery(payload)
+
+    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
+    expect(mockSearchQuery).toHaveBeenCalledWith(payload)
+    expect(response).toEqual(results)
+  })
+
+  it('supports filters-only payloads', async () => {
+    const store = useSearchStore()
+    const payload: SearchQueryRequest = {
+      filters: [{ kind: 'model_author', term: 'Noble' }],
+    }
+    const results = [buildResult('/r/filters-only')]
+    mockSearchQuery.mockResolvedValue({ results })
+
+    const response = await store.searchQuery(payload)
+
+    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
+    expect(mockSearchQuery).toHaveBeenCalledWith(payload)
+    expect(response).toEqual(results)
+  })
+
+  it('uses separate cache entries for distinct filters', async () => {
+    const store = useSearchStore()
+    const resultA = [buildResult('/r/filter-a')]
+    const resultB = [buildResult('/r/filter-b')]
+
+    mockSearchQuery.mockImplementation(async (search) => {
+      const term = search.filters?.[0]?.term
+      return { results: term === 'a' ? resultA : resultB }
+    })
+
+    const payloadA: SearchQueryRequest = {
+      query: 'same query',
+      filters: [{ kind: 'cellml_keyword', term: 'a' }],
+    }
+    const payloadB: SearchQueryRequest = {
+      query: 'same query',
+      filters: [{ kind: 'cellml_keyword', term: 'b' }],
+    }
+
+    const first = await store.searchQuery(payloadA)
+    const second = await store.searchQuery(payloadA)
+    const third = await store.searchQuery(payloadB)
+
+    expect(first).toEqual(resultA)
+    expect(second).toEqual(resultA)
+    expect(third).toEqual(resultB)
+    expect(mockSearchQuery).toHaveBeenCalledTimes(2)
+    expect(mockSearchQuery).toHaveBeenNthCalledWith(1, payloadA)
+    expect(mockSearchQuery).toHaveBeenNthCalledWith(2, payloadB)
+  })
+})

--- a/src/stores/search.test.ts
+++ b/src/stores/search.test.ts
@@ -254,7 +254,7 @@ describe('useSearchStore searchQuery', () => {
     mockSearchQuery.mockResolvedValue({ results })
 
     const unsanitisedPayload: SearchQueryRequest = {
-      query: "  Noble (1962)  ",
+      query: '  Noble (1962)  ',
       filters: [{ kind: 'cellml_keyword', term: 'a' }],
     }
     const sanitisedPayload: SearchQueryRequest = {

--- a/src/stores/search.test.ts
+++ b/src/stores/search.test.ts
@@ -79,6 +79,65 @@ describe('useSearchStore searchQuery', () => {
     expect(response).toEqual(results)
   })
 
+  it('omits empty query values before calling the service', async () => {
+    const store = useSearchStore()
+    const payload: SearchQueryRequest = {
+      query: '',
+      filters: [{ kind: 'model_author', term: 'Noble' }],
+    }
+    const results = [buildResult('/r/filters-only')]
+    mockSearchQuery.mockResolvedValue({ results })
+
+    const response = await store.searchQuery(payload)
+
+    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
+    expect(mockSearchQuery).toHaveBeenCalledWith({
+      filters: [{ kind: 'model_author', term: 'Noble' }],
+    })
+    expect(response).toEqual(results)
+  })
+
+  it('omits whitespace-only query values before calling the service', async () => {
+    const store = useSearchStore()
+    const payload: SearchQueryRequest = {
+      query: '   ',
+      filters: [{ kind: 'model_author', term: 'Noble' }],
+    }
+    const results = [buildResult('/r/filters-only')]
+    mockSearchQuery.mockResolvedValue({ results })
+
+    const response = await store.searchQuery(payload)
+
+    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
+    expect(mockSearchQuery).toHaveBeenCalledWith({
+      filters: [{ kind: 'model_author', term: 'Noble' }],
+    })
+    expect(response).toEqual(results)
+  })
+
+  it('filters out invalid filters before calling the service', async () => {
+    const store = useSearchStore()
+    const payload: SearchQueryRequest = {
+      query: 'valid query',
+      filters: [
+        { kind: 'model_author', term: 'Noble' },
+        { kind: '', term: 'invalid' },
+        { kind: 'invalid', term: '' },
+      ],
+    }
+    const results = [buildResult('/r/filtered-filters')]
+    mockSearchQuery.mockResolvedValue({ results })
+
+    const response = await store.searchQuery(payload)
+
+    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
+    expect(mockSearchQuery).toHaveBeenCalledWith({
+      query: 'valid query',
+      filters: [{ kind: 'model_author', term: 'Noble' }],
+    })
+    expect(response).toEqual(results)
+  })
+
   it('uses separate cache entries for distinct filters', async () => {
     const store = useSearchStore()
     const resultA = [buildResult('/r/filter-a')]

--- a/src/stores/search.test.ts
+++ b/src/stores/search.test.ts
@@ -83,58 +83,20 @@ describe('useSearchStore searchQuery', () => {
     expect(response).toEqual(results)
   })
 
-  it('replaces unsupported special characters in query values before calling the service', async () => {
+  it('preserves special characters in query values after trimming', async () => {
     const store = useSearchStore()
     const payload: SearchQueryRequest = {
       query: "  Noble (1962) Bhalla & Iyengar O'Hara-Rudy ca2+ ca2 +  ",
       filters: [{ kind: '  cellml_keyword  ', term: '  action-potential  ' }],
     }
-    const results = [buildResult('/r/sanitised-query')]
+    const results = [buildResult('/r/special-characters')]
     mockSearchQuery.mockResolvedValue({ results })
 
     const response = await store.searchQuery(payload)
 
     expect(mockSearchQuery).toHaveBeenCalledTimes(1)
     expect(mockSearchQuery).toHaveBeenCalledWith({
-      query: 'Noble 1962 Bhalla Iyengar O Hara Rudy ca2+ ca2',
-      filters: [{ kind: 'cellml_keyword', term: 'action-potential' }],
-    })
-    expect(response).toEqual(results)
-  })
-
-  it('preserves plus only for tokens with two or more characters', async () => {
-    const store = useSearchStore()
-    const payload: SearchQueryRequest = {
-      query: 'ca2+ ca+ c+ ca 2+ Ca+/K+',
-      filters: [{ kind: 'cellml_keyword', term: 'action-potential' }],
-    }
-    const results = [buildResult('/r/plus-token-length')]
-    mockSearchQuery.mockResolvedValue({ results })
-
-    const response = await store.searchQuery(payload)
-
-    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
-    expect(mockSearchQuery).toHaveBeenCalledWith({
-      query: 'ca2+ ca+ c ca 2 Ca+ K',
-      filters: [{ kind: 'cellml_keyword', term: 'action-potential' }],
-    })
-    expect(response).toEqual(results)
-  })
-
-  it('does not alter literal placeholder text in query values', async () => {
-    const store = useSearchStore()
-    const payload: SearchQueryRequest = {
-      query: 'PMRSEARCHPLUSPLACEHOLDER ca2+ ca2 +',
-      filters: [{ kind: 'cellml_keyword', term: 'action-potential' }],
-    }
-    const results = [buildResult('/r/placeholder-literal')]
-    mockSearchQuery.mockResolvedValue({ results })
-
-    const response = await store.searchQuery(payload)
-
-    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
-    expect(mockSearchQuery).toHaveBeenCalledWith({
-      query: 'PMRSEARCHPLUSPLACEHOLDER ca2+ ca2',
+      query: "Noble (1962) Bhalla & Iyengar O'Hara-Rudy ca2+ ca2 +",
       filters: [{ kind: 'cellml_keyword', term: 'action-potential' }],
     })
     expect(response).toEqual(results)
@@ -177,24 +139,6 @@ describe('useSearchStore searchQuery', () => {
     const store = useSearchStore()
     const payload: SearchQueryRequest = {
       query: '   ',
-      filters: [{ kind: 'model_author', term: 'Noble' }],
-    }
-    const results = [buildResult('/r/filters-only')]
-    mockSearchQuery.mockResolvedValue({ results })
-
-    const response = await store.searchQuery(payload)
-
-    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
-    expect(mockSearchQuery).toHaveBeenCalledWith({
-      filters: [{ kind: 'model_author', term: 'Noble' }],
-    })
-    expect(response).toEqual(results)
-  })
-
-  it('omits query values that become empty after sanitisation', async () => {
-    const store = useSearchStore()
-    const payload: SearchQueryRequest = {
-      query: ' () & - ',
       filters: [{ kind: 'model_author', term: 'Noble' }],
     }
     const results = [buildResult('/r/filters-only')]
@@ -286,26 +230,37 @@ describe('useSearchStore searchQuery', () => {
     expect(mockSearchQuery).toHaveBeenCalledWith(trimmedPayload)
   })
 
-  it('reuses the cache for semantically identical sanitised queries', async () => {
+  it('uses separate cache entries for different query text values', async () => {
     const store = useSearchStore()
-    const results = [buildResult('/r/sanitised-cache')]
-    mockSearchQuery.mockResolvedValue({ results })
+    const unsanitisedResults = [buildResult('/r/unsanitised')]
+    const trimmedResults = [buildResult('/r/trimmed')]
+
+    mockSearchQuery.mockImplementation(async (search) => {
+      if (search.query === 'Noble (1962)') {
+        return { results: unsanitisedResults }
+      }
+      return { results: trimmedResults }
+    })
 
     const unsanitisedPayload: SearchQueryRequest = {
       query: '  Noble (1962)  ',
       filters: [{ kind: 'cellml_keyword', term: 'a' }],
     }
-    const sanitisedPayload: SearchQueryRequest = {
+    const trimmedPayload: SearchQueryRequest = {
       query: 'Noble 1962',
       filters: [{ kind: 'cellml_keyword', term: 'a' }],
     }
 
     const first = await store.searchQuery(unsanitisedPayload)
-    const second = await store.searchQuery(sanitisedPayload)
+    const second = await store.searchQuery(trimmedPayload)
 
-    expect(first).toEqual(results)
-    expect(second).toEqual(results)
-    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
-    expect(mockSearchQuery).toHaveBeenCalledWith(sanitisedPayload)
+    expect(first).toEqual(unsanitisedResults)
+    expect(second).toEqual(trimmedResults)
+    expect(mockSearchQuery).toHaveBeenCalledTimes(2)
+    expect(mockSearchQuery).toHaveBeenNthCalledWith(1, {
+      query: 'Noble (1962)',
+      filters: [{ kind: 'cellml_keyword', term: 'a' }],
+    })
+    expect(mockSearchQuery).toHaveBeenNthCalledWith(2, trimmedPayload)
   })
 })

--- a/src/stores/search.test.ts
+++ b/src/stores/search.test.ts
@@ -102,6 +102,25 @@ describe('useSearchStore searchQuery', () => {
     expect(response).toEqual(results)
   })
 
+  it('preserves plus only for tokens with two or more characters', async () => {
+    const store = useSearchStore()
+    const payload: SearchQueryRequest = {
+      query: 'ca2+ ca+ c+ ca 2+ Ca+/K+',
+      filters: [{ kind: 'cellml_keyword', term: 'action-potential' }],
+    }
+    const results = [buildResult('/r/plus-token-length')]
+    mockSearchQuery.mockResolvedValue({ results })
+
+    const response = await store.searchQuery(payload)
+
+    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
+    expect(mockSearchQuery).toHaveBeenCalledWith({
+      query: 'ca2+ ca+ c ca 2 Ca+ K',
+      filters: [{ kind: 'cellml_keyword', term: 'action-potential' }],
+    })
+    expect(response).toEqual(results)
+  })
+
   it('does not alter literal placeholder text in query values', async () => {
     const store = useSearchStore()
     const payload: SearchQueryRequest = {

--- a/src/stores/search.test.ts
+++ b/src/stores/search.test.ts
@@ -35,15 +35,16 @@ describe('useSearchStore searchQuery', () => {
     mockSearchQuery.mockReset()
   })
 
-  it('normalizes legacy string input to request payload', async () => {
+  it('supports query-only payloads', async () => {
     const store = useSearchStore()
-    const results = [buildResult('/r/legacy')]
+    const results = [buildResult('/r/query-only')]
     mockSearchQuery.mockResolvedValue({ results })
 
-    const response = await store.searchQuery('legacy query')
+    const payload: SearchQueryRequest = { query: 'query-only' }
+    const response = await store.searchQuery(payload)
 
     expect(mockSearchQuery).toHaveBeenCalledTimes(1)
-    expect(mockSearchQuery).toHaveBeenCalledWith({ query: 'legacy query' })
+    expect(mockSearchQuery).toHaveBeenCalledWith(payload)
     expect(response).toEqual(results)
   })
 

--- a/src/stores/search.test.ts
+++ b/src/stores/search.test.ts
@@ -102,6 +102,25 @@ describe('useSearchStore searchQuery', () => {
     expect(response).toEqual(results)
   })
 
+  it('does not alter literal placeholder text in query values', async () => {
+    const store = useSearchStore()
+    const payload: SearchQueryRequest = {
+      query: 'PMRSEARCHPLUSPLACEHOLDER ca2+ ca2 +',
+      filters: [{ kind: 'cellml_keyword', term: 'action-potential' }],
+    }
+    const results = [buildResult('/r/placeholder-literal')]
+    mockSearchQuery.mockResolvedValue({ results })
+
+    const response = await store.searchQuery(payload)
+
+    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
+    expect(mockSearchQuery).toHaveBeenCalledWith({
+      query: 'PMRSEARCHPLUSPLACEHOLDER ca2+ ca2',
+      filters: [{ kind: 'cellml_keyword', term: 'action-potential' }],
+    })
+    expect(response).toEqual(results)
+  })
+
   it('supports filters-only payloads', async () => {
     const store = useSearchStore()
     const payload: SearchQueryRequest = {

--- a/src/stores/search.test.ts
+++ b/src/stores/search.test.ts
@@ -40,7 +40,7 @@ describe('useSearchStore searchQuery', () => {
     const results = [buildResult('/r/query-only')]
     mockSearchQuery.mockResolvedValue({ results })
 
-    const payload: SearchQueryRequest = { query: 'query-only' }
+    const payload: SearchQueryRequest = { query: 'query only' }
     const response = await store.searchQuery(payload)
 
     expect(mockSearchQuery).toHaveBeenCalledTimes(1)
@@ -83,6 +83,25 @@ describe('useSearchStore searchQuery', () => {
     expect(response).toEqual(results)
   })
 
+  it('replaces unsupported special characters in query values before calling the service', async () => {
+    const store = useSearchStore()
+    const payload: SearchQueryRequest = {
+      query: "  Noble (1962) Bhalla & Iyengar O'Hara-Rudy ca2+ ca2 +  ",
+      filters: [{ kind: '  cellml_keyword  ', term: '  action-potential  ' }],
+    }
+    const results = [buildResult('/r/sanitised-query')]
+    mockSearchQuery.mockResolvedValue({ results })
+
+    const response = await store.searchQuery(payload)
+
+    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
+    expect(mockSearchQuery).toHaveBeenCalledWith({
+      query: 'Noble 1962 Bhalla Iyengar O Hara Rudy ca2+ ca2',
+      filters: [{ kind: 'cellml_keyword', term: 'action-potential' }],
+    })
+    expect(response).toEqual(results)
+  })
+
   it('supports filters-only payloads', async () => {
     const store = useSearchStore()
     const payload: SearchQueryRequest = {
@@ -120,6 +139,24 @@ describe('useSearchStore searchQuery', () => {
     const store = useSearchStore()
     const payload: SearchQueryRequest = {
       query: '   ',
+      filters: [{ kind: 'model_author', term: 'Noble' }],
+    }
+    const results = [buildResult('/r/filters-only')]
+    mockSearchQuery.mockResolvedValue({ results })
+
+    const response = await store.searchQuery(payload)
+
+    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
+    expect(mockSearchQuery).toHaveBeenCalledWith({
+      filters: [{ kind: 'model_author', term: 'Noble' }],
+    })
+    expect(response).toEqual(results)
+  })
+
+  it('omits query values that become empty after sanitisation', async () => {
+    const store = useSearchStore()
+    const payload: SearchQueryRequest = {
+      query: ' () & - ',
       filters: [{ kind: 'model_author', term: 'Noble' }],
     }
     const results = [buildResult('/r/filters-only')]
@@ -209,5 +246,28 @@ describe('useSearchStore searchQuery', () => {
     expect(second).toEqual(results)
     expect(mockSearchQuery).toHaveBeenCalledTimes(1)
     expect(mockSearchQuery).toHaveBeenCalledWith(trimmedPayload)
+  })
+
+  it('reuses the cache for semantically identical sanitised queries', async () => {
+    const store = useSearchStore()
+    const results = [buildResult('/r/sanitised-cache')]
+    mockSearchQuery.mockResolvedValue({ results })
+
+    const unsanitisedPayload: SearchQueryRequest = {
+      query: "  Noble (1962)  ",
+      filters: [{ kind: 'cellml_keyword', term: 'a' }],
+    }
+    const sanitisedPayload: SearchQueryRequest = {
+      query: 'Noble 1962',
+      filters: [{ kind: 'cellml_keyword', term: 'a' }],
+    }
+
+    const first = await store.searchQuery(unsanitisedPayload)
+    const second = await store.searchQuery(sanitisedPayload)
+
+    expect(first).toEqual(results)
+    expect(second).toEqual(results)
+    expect(mockSearchQuery).toHaveBeenCalledTimes(1)
+    expect(mockSearchQuery).toHaveBeenCalledWith(sanitisedPayload)
   })
 })

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -31,6 +31,10 @@ interface TimedCacheEntry {
   timestamp: number
 }
 
+// Temporary token used while sanitising query text so attached plus signs
+// (for example, "ca2+") survive special-character replacement.
+const PROTECTED_PLUS_PLACEHOLDER = 'PMRSEARCHPLUSPLACEHOLDER'
+
 export const useSearchStore = defineStore('search', () => {
   const categories = ref<CategoryData[]>([])
   const lastFetchTime = ref<number | null>(null)
@@ -68,15 +72,26 @@ export const useSearchStore = defineStore('search', () => {
     return now - lastFetchTime.value < CACHE_TTL
   }
 
+  const normaliseSearchQueryText = (query: string): string => {
+    const trimmedQuery = query.trim()
+
+    return trimmedQuery
+      .replace(/([\p{L}\p{N}])\+(?=[\p{L}\p{N}]|\s|$)/gu, `$1${PROTECTED_PLUS_PLACEHOLDER}`)
+      .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .replaceAll(PROTECTED_PLUS_PLACEHOLDER, '+')
+  }
+
   // Removes empty query text and invalid filters
   // before using the payload for cache keys and API calls.
   const normaliseSearchQueryRequest = (request: SearchQueryRequest): SearchQueryRequest => {
     const normalisedRequest: SearchQueryRequest = {}
 
     if (typeof request.query === 'string') {
-      const trimmedQuery = request.query.trim()
-      if (trimmedQuery !== '') {
-        normalisedRequest.query = trimmedQuery
+      const normalisedQuery = normaliseSearchQueryText(request.query)
+      if (normalisedQuery !== '') {
+        normalisedRequest.query = normalisedQuery
       }
     }
 

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -93,7 +93,7 @@ export const useSearchStore = defineStore('search', () => {
     const protectedPlusPlaceholder = getProtectedPlusPlaceholder(trimmedQuery)
 
     return trimmedQuery
-      .replace(/([\p{L}\p{N}])\+(?=[\p{L}\p{N}]|\s|$)/gu, `$1${protectedPlusPlaceholder}`)
+      .replace(/([\p{L}\p{N}]{2,})\+(?=$|[^\p{L}\p{N}])/gu, `$1${protectedPlusPlaceholder}`)
       .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
       .replace(/\s+/g, ' ')
       .trim()

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -4,6 +4,8 @@ import { getSearchService } from '@/services'
 import type { IndexKindResponse, SearchResult } from '@/types/search'
 
 const CACHE_TTL = 30 * 60 * 1000 // 30 minutes in milliseconds
+const SEARCH_RESULTS_CACHE_MAX_SIZE = 200 // Keep up to 200 cached kind/term search entries.
+const SEARCH_QUERY_CACHE_MAX_SIZE = 200 // Keep up to 200 cached free-text query entries.
 
 export interface CategoryData {
   kind: string
@@ -25,6 +27,10 @@ export interface SearchQueryCache {
   timestamp: number
 }
 
+interface TimedCacheEntry {
+  timestamp: number
+}
+
 export const useSearchStore = defineStore('search', () => {
   const categories = ref<CategoryData[]>([])
   const lastFetchTime = ref<number | null>(null)
@@ -32,6 +38,29 @@ export const useSearchStore = defineStore('search', () => {
   const error = ref<string | null>(null)
   const searchResultsCache = ref<Map<string, SearchResultCache>>(new Map())
   const searchQueryCache = ref<Map<string, SearchQueryCache>>(new Map())
+
+  const pruneExpiredEntries = <T extends TimedCacheEntry>(cache: Map<string, T>, now: number) => {
+    for (const [key, entry] of cache.entries()) {
+      if (now - entry.timestamp >= CACHE_TTL) {
+        cache.delete(key)
+      }
+    }
+  }
+
+  const touchCacheEntry = <T>(cache: Map<string, T>, key: string, value: T) => {
+    cache.delete(key)
+    cache.set(key, value)
+  }
+
+  const enforceMaxCacheSize = <T>(cache: Map<string, T>, maxSize: number) => {
+    while (cache.size > maxSize) {
+      const oldestKey = cache.keys().next().value
+      if (oldestKey === undefined) {
+        break
+      }
+      cache.delete(oldestKey)
+    }
+  }
 
   const isCacheValid = (): boolean => {
     if (!lastFetchTime.value) return false
@@ -112,10 +141,13 @@ export const useSearchStore = defineStore('search', () => {
     forceRefresh = false,
   ): Promise<SearchResult[]> => {
     const cacheKey = `${kind}:${term}`
+    const now = Date.now()
+    pruneExpiredEntries(searchResultsCache.value, now)
     const cached = searchResultsCache.value.get(cacheKey)
 
     // Return cached results if valid.
-    if (!forceRefresh && cached && Date.now() - cached.timestamp < CACHE_TTL) {
+    if (!forceRefresh && cached) {
+      touchCacheEntry(searchResultsCache.value, cacheKey, cached)
       return cached.results
     }
 
@@ -125,12 +157,13 @@ export const useSearchStore = defineStore('search', () => {
       const results = response?.resource_paths || []
 
       // Cache the results.
-      searchResultsCache.value.set(cacheKey, {
+      touchCacheEntry(searchResultsCache.value, cacheKey, {
         kind,
         term,
         results,
         timestamp: Date.now(),
       })
+      enforceMaxCacheSize(searchResultsCache.value, SEARCH_RESULTS_CACHE_MAX_SIZE)
 
       return results
     } catch (err) {
@@ -141,10 +174,13 @@ export const useSearchStore = defineStore('search', () => {
 
   const searchQuery = async (query: string, forceRefresh = false): Promise<SearchResult[]> => {
     const cacheKey = query
+    const now = Date.now()
+    pruneExpiredEntries(searchQueryCache.value, now)
     const cached = searchQueryCache.value.get(cacheKey)
 
     // Return cached results if valid.
-    if (!forceRefresh && cached && Date.now() - cached.timestamp < CACHE_TTL) {
+    if (!forceRefresh && cached) {
+      touchCacheEntry(searchQueryCache.value, cacheKey, cached)
       return cached.results
     }
 
@@ -154,11 +190,12 @@ export const useSearchStore = defineStore('search', () => {
       const results = response?.results || []
 
       // Cache the results.
-      searchQueryCache.value.set(cacheKey, {
+      touchCacheEntry(searchQueryCache.value, cacheKey, {
         query,
         results,
         timestamp: Date.now(),
       })
+      enforceMaxCacheSize(searchQueryCache.value, SEARCH_QUERY_CACHE_MAX_SIZE)
 
       return results
     } catch (err) {

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -68,24 +68,22 @@ export const useSearchStore = defineStore('search', () => {
     return now - lastFetchTime.value < CACHE_TTL
   }
 
+  // Removes empty query text and invalid filters
+  // before using the payload for cache keys and API calls.
   const normaliseSearchQueryRequest = (
     request: SearchQueryRequest
   ): SearchQueryRequest => {
-    // Create a new object to hold the cleaned data
     const normalisedRequest: SearchQueryRequest = {}
 
-    // 1. Handle the query: Only add it if it is defined and not just empty space
     if (typeof request.query === 'string' && request.query.trim() !== '') {
       normalisedRequest.query = request.query
     }
 
-    // 2. Handle the filters: Filter out any items with empty terms or values
     if (Array.isArray(request.filters)) {
       const validFilters = request.filters.filter(
         (filter) => filter.kind.trim() !== '' && filter.term.trim() !== ''
       )
 
-      // Only attach the filters array if there are valid filters left
       if (validFilters.length > 0) {
         normalisedRequest.filters = validFilters
       }
@@ -203,7 +201,6 @@ export const useSearchStore = defineStore('search', () => {
     forceRefresh = false,
   ): Promise<SearchResult[]> => {
     const normalisedRequest = normaliseSearchQueryRequest(searchQueryRequest)
-    console.log('normalisedRequest', normalisedRequest)
     const cacheKey = JSON.stringify(normalisedRequest)
     const now = Date.now()
     pruneExpiredEntries(searchQueryCache.value, now)

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -31,10 +31,6 @@ interface TimedCacheEntry {
   timestamp: number
 }
 
-// Base token used to build a per-query placeholder so attached plus signs
-// (for example, "ca2+") survive special-character replacement.
-const PROTECTED_PLUS_PLACEHOLDER_BASE = 'PMRSEARCHPLUSPLACEHOLDER'
-
 export const useSearchStore = defineStore('search', () => {
   const categories = ref<CategoryData[]>([])
   const lastFetchTime = ref<number | null>(null)
@@ -72,41 +68,13 @@ export const useSearchStore = defineStore('search', () => {
     return now - lastFetchTime.value < CACHE_TTL
   }
 
-  const getProtectedPlusPlaceholder = (query: string): string => {
-    if (!query.includes(PROTECTED_PLUS_PLACEHOLDER_BASE)) {
-      return PROTECTED_PLUS_PLACEHOLDER_BASE
-    }
-
-    let suffix = 0
-    let placeholder = `${PROTECTED_PLUS_PLACEHOLDER_BASE}${suffix}`
-
-    while (query.includes(placeholder)) {
-      suffix += 1
-      placeholder = `${PROTECTED_PLUS_PLACEHOLDER_BASE}${suffix}`
-    }
-
-    return placeholder
-  }
-
-  const normaliseSearchQueryText = (query: string): string => {
-    const trimmedQuery = query.trim()
-    const protectedPlusPlaceholder = getProtectedPlusPlaceholder(trimmedQuery)
-
-    return trimmedQuery
-      .replace(/([\p{L}\p{N}]{2,})\+(?=$|[^\p{L}\p{N}])/gu, `$1${protectedPlusPlaceholder}`)
-      .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
-      .replace(/\s+/g, ' ')
-      .trim()
-      .replaceAll(protectedPlusPlaceholder, '+')
-  }
-
   // Removes empty query text and invalid filters
   // before using the payload for cache keys and API calls.
   const normaliseSearchQueryRequest = (request: SearchQueryRequest): SearchQueryRequest => {
     const normalisedRequest: SearchQueryRequest = {}
 
     if (typeof request.query === 'string') {
-      const normalisedQuery = normaliseSearchQueryText(request.query)
+      const normalisedQuery = request.query.trim()
       if (normalisedQuery !== '') {
         normalisedRequest.query = normalisedQuery
       }

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -173,14 +173,12 @@ export const useSearchStore = defineStore('search', () => {
   }
 
   const searchQuery = async (
-    search: string | SearchQueryRequest,
+    searchQueryRequest: SearchQueryRequest,
     forceRefresh = false,
   ): Promise<SearchResult[]> => {
-    const normalisedSearch: SearchQueryRequest =
-      typeof search === 'string' ? { query: search } : search
     const cacheKey = JSON.stringify({
-      query: normalisedSearch.query ?? '',
-      filters: (normalisedSearch.filters ?? []).map(({ kind, term }) => ({ kind, term })),
+      query: searchQueryRequest.query ?? '',
+      filters: (searchQueryRequest.filters ?? []).map(({ kind, term }) => ({ kind, term })),
     })
     const now = Date.now()
     pruneExpiredEntries(searchQueryCache.value, now)
@@ -194,12 +192,12 @@ export const useSearchStore = defineStore('search', () => {
 
     try {
       const searchService = getSearchService()
-      const response = await searchService.searchQuery(normalisedSearch)
+      const response = await searchService.searchQuery(searchQueryRequest)
       const results = response?.results || []
 
       // Cache the results.
       touchCacheEntry(searchQueryCache.value, cacheKey, {
-        search: normalisedSearch,
+        search: searchQueryRequest,
         results,
         timestamp: Date.now(),
       })

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -68,6 +68,32 @@ export const useSearchStore = defineStore('search', () => {
     return now - lastFetchTime.value < CACHE_TTL
   }
 
+  const normaliseSearchQueryRequest = (
+    request: SearchQueryRequest
+  ): SearchQueryRequest => {
+    // Create a new object to hold the cleaned data
+    const normalisedRequest: SearchQueryRequest = {}
+
+    // 1. Handle the query: Only add it if it is defined and not just empty space
+    if (typeof request.query === 'string' && request.query.trim() !== '') {
+      normalisedRequest.query = request.query
+    }
+
+    // 2. Handle the filters: Filter out any items with empty terms or values
+    if (Array.isArray(request.filters)) {
+      const validFilters = request.filters.filter(
+        (filter) => filter.kind.trim() !== '' && filter.term.trim() !== ''
+      )
+
+      // Only attach the filters array if there are valid filters left
+      if (validFilters.length > 0) {
+        normalisedRequest.filters = validFilters
+      }
+    }
+
+    return normalisedRequest
+  }
+
   const fetchCategories = async (
     categoryIndexesOrForceRefresh?: string[] | boolean,
     forceRefreshParam?: boolean,
@@ -176,10 +202,9 @@ export const useSearchStore = defineStore('search', () => {
     searchQueryRequest: SearchQueryRequest,
     forceRefresh = false,
   ): Promise<SearchResult[]> => {
-    const cacheKey = JSON.stringify({
-      query: searchQueryRequest.query ?? '',
-      filters: (searchQueryRequest.filters ?? []).map(({ kind, term }) => ({ kind, term })),
-    })
+    const normalisedRequest = normaliseSearchQueryRequest(searchQueryRequest)
+    console.log('normalisedRequest', normalisedRequest)
+    const cacheKey = JSON.stringify(normalisedRequest)
     const now = Date.now()
     pruneExpiredEntries(searchQueryCache.value, now)
     const cached = searchQueryCache.value.get(cacheKey)
@@ -192,12 +217,12 @@ export const useSearchStore = defineStore('search', () => {
 
     try {
       const searchService = getSearchService()
-      const response = await searchService.searchQuery(searchQueryRequest)
+      const response = await searchService.searchQuery(normalisedRequest)
       const results = response?.results || []
 
       // Cache the results.
       touchCacheEntry(searchQueryCache.value, cacheKey, {
-        search: searchQueryRequest,
+        search: normalisedRequest,
         results,
         timestamp: Date.now(),
       })

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -73,14 +73,20 @@ export const useSearchStore = defineStore('search', () => {
   const normaliseSearchQueryRequest = (request: SearchQueryRequest): SearchQueryRequest => {
     const normalisedRequest: SearchQueryRequest = {}
 
-    if (typeof request.query === 'string' && request.query.trim() !== '') {
-      normalisedRequest.query = request.query
+    if (typeof request.query === 'string') {
+      const trimmedQuery = request.query.trim()
+      if (trimmedQuery !== '') {
+        normalisedRequest.query = trimmedQuery
+      }
     }
 
     if (Array.isArray(request.filters)) {
-      const validFilters = request.filters.filter(
-        (filter) => filter.kind.trim() !== '' && filter.term.trim() !== '',
-      )
+      const validFilters = request.filters
+        .map((filter) => ({
+          kind: filter.kind.trim(),
+          term: filter.term.trim(),
+        }))
+        .filter((filter) => filter.kind !== '' && filter.term !== '')
 
       if (validFilters.length > 0) {
         normalisedRequest.filters = validFilters

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -19,12 +19,19 @@ export interface SearchResultCache {
   timestamp: number
 }
 
+export interface SearchQueryCache {
+  query: string
+  results: SearchResult[]
+  timestamp: number
+}
+
 export const useSearchStore = defineStore('search', () => {
   const categories = ref<CategoryData[]>([])
   const lastFetchTime = ref<number | null>(null)
   const isLoading = ref(false)
   const error = ref<string | null>(null)
   const searchResultsCache = ref<Map<string, SearchResultCache>>(new Map())
+  const searchQueryCache = ref<Map<string, SearchQueryCache>>(new Map())
 
   const isCacheValid = (): boolean => {
     if (!lastFetchTime.value) return false
@@ -132,11 +139,40 @@ export const useSearchStore = defineStore('search', () => {
     }
   }
 
+  const searchQuery = async (query: string, forceRefresh = false): Promise<SearchResult[]> => {
+    const cacheKey = query
+    const cached = searchQueryCache.value.get(cacheKey)
+
+    // Return cached results if valid.
+    if (!forceRefresh && cached && Date.now() - cached.timestamp < CACHE_TTL) {
+      return cached.results
+    }
+
+    try {
+      const searchService = getSearchService()
+      const response = await searchService.searchQuery(query)
+      const results = response?.results || []
+
+      // Cache the results.
+      searchQueryCache.value.set(cacheKey, {
+        query,
+        results,
+        timestamp: Date.now(),
+      })
+
+      return results
+    } catch (err) {
+      console.error('Search query error:', err)
+      throw err
+    }
+  }
+
   return {
     categories,
     isLoading,
     error,
     fetchCategories,
     searchIndexTerm,
+    searchQuery,
   }
 })

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import { getSearchService } from '@/services'
-import type { IndexKindResponse, SearchResult } from '@/types/search'
+import type { IndexKindResponse, SearchQueryRequest, SearchResult } from '@/types/search'
 
 const CACHE_TTL = 30 * 60 * 1000 // 30 minutes in milliseconds
 const SEARCH_RESULTS_CACHE_MAX_SIZE = 200 // Keep up to 200 cached kind/term search entries.
@@ -22,7 +22,7 @@ export interface SearchResultCache {
 }
 
 export interface SearchQueryCache {
-  query: string
+  search: SearchQueryRequest
   results: SearchResult[]
   timestamp: number
 }
@@ -172,8 +172,16 @@ export const useSearchStore = defineStore('search', () => {
     }
   }
 
-  const searchQuery = async (query: string, forceRefresh = false): Promise<SearchResult[]> => {
-    const cacheKey = query
+  const searchQuery = async (
+    search: string | SearchQueryRequest,
+    forceRefresh = false,
+  ): Promise<SearchResult[]> => {
+    const normalisedSearch: SearchQueryRequest =
+      typeof search === 'string' ? { query: search } : search
+    const cacheKey = JSON.stringify({
+      query: normalisedSearch.query ?? '',
+      filters: (normalisedSearch.filters ?? []).map(({ kind, term }) => ({ kind, term })),
+    })
     const now = Date.now()
     pruneExpiredEntries(searchQueryCache.value, now)
     const cached = searchQueryCache.value.get(cacheKey)
@@ -186,12 +194,12 @@ export const useSearchStore = defineStore('search', () => {
 
     try {
       const searchService = getSearchService()
-      const response = await searchService.searchQuery(query)
+      const response = await searchService.searchQuery(normalisedSearch)
       const results = response?.results || []
 
       // Cache the results.
       touchCacheEntry(searchQueryCache.value, cacheKey, {
-        query,
+        search: normalisedSearch,
         results,
         timestamp: Date.now(),
       })

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -31,9 +31,9 @@ interface TimedCacheEntry {
   timestamp: number
 }
 
-// Temporary token used while sanitising query text so attached plus signs
+// Base token used to build a per-query placeholder so attached plus signs
 // (for example, "ca2+") survive special-character replacement.
-const PROTECTED_PLUS_PLACEHOLDER = 'PMRSEARCHPLUSPLACEHOLDER'
+const PROTECTED_PLUS_PLACEHOLDER_BASE = 'PMRSEARCHPLUSPLACEHOLDER'
 
 export const useSearchStore = defineStore('search', () => {
   const categories = ref<CategoryData[]>([])
@@ -72,15 +72,32 @@ export const useSearchStore = defineStore('search', () => {
     return now - lastFetchTime.value < CACHE_TTL
   }
 
+  const getProtectedPlusPlaceholder = (query: string): string => {
+    if (!query.includes(PROTECTED_PLUS_PLACEHOLDER_BASE)) {
+      return PROTECTED_PLUS_PLACEHOLDER_BASE
+    }
+
+    let suffix = 0
+    let placeholder = `${PROTECTED_PLUS_PLACEHOLDER_BASE}${suffix}`
+
+    while (query.includes(placeholder)) {
+      suffix += 1
+      placeholder = `${PROTECTED_PLUS_PLACEHOLDER_BASE}${suffix}`
+    }
+
+    return placeholder
+  }
+
   const normaliseSearchQueryText = (query: string): string => {
     const trimmedQuery = query.trim()
+    const protectedPlusPlaceholder = getProtectedPlusPlaceholder(trimmedQuery)
 
     return trimmedQuery
-      .replace(/([\p{L}\p{N}])\+(?=[\p{L}\p{N}]|\s|$)/gu, `$1${PROTECTED_PLUS_PLACEHOLDER}`)
+      .replace(/([\p{L}\p{N}])\+(?=[\p{L}\p{N}]|\s|$)/gu, `$1${protectedPlusPlaceholder}`)
       .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
       .replace(/\s+/g, ' ')
       .trim()
-      .replaceAll(PROTECTED_PLUS_PLACEHOLDER, '+')
+      .replaceAll(protectedPlusPlaceholder, '+')
   }
 
   // Removes empty query text and invalid filters

--- a/src/stores/search.ts
+++ b/src/stores/search.ts
@@ -70,9 +70,7 @@ export const useSearchStore = defineStore('search', () => {
 
   // Removes empty query text and invalid filters
   // before using the payload for cache keys and API calls.
-  const normaliseSearchQueryRequest = (
-    request: SearchQueryRequest
-  ): SearchQueryRequest => {
+  const normaliseSearchQueryRequest = (request: SearchQueryRequest): SearchQueryRequest => {
     const normalisedRequest: SearchQueryRequest = {}
 
     if (typeof request.query === 'string' && request.query.trim() !== '') {
@@ -81,7 +79,7 @@ export const useSearchStore = defineStore('search', () => {
 
     if (Array.isArray(request.filters)) {
       const validFilters = request.filters.filter(
-        (filter) => filter.kind.trim() !== '' && filter.term.trim() !== ''
+        (filter) => filter.kind.trim() !== '' && filter.term.trim() !== '',
       )
 
       if (validFilters.length > 0) {

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -25,8 +25,8 @@ export interface SearchResult {
     citation_author_family_name: string[]
     citation_id: string[]
     model_author: string[]
-    _title: string[]
-    _brief: string[]
+    _title?: string[]
+    _brief?: string[]
   }
   resource_path: string
 }

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -44,6 +44,16 @@ export interface SearchQueryResponse {
   results: SearchResult[]
 }
 
+export interface SearchFilter {
+  kind: string
+  term: string
+}
+
+export interface SearchQueryRequest {
+  query?: string
+  filters?: SearchFilter[]
+}
+
 export interface TextSegment {
   text: string
   highlighted: boolean

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -25,6 +25,8 @@ export interface SearchResult {
     citation_author_family_name: string[]
     citation_id: string[]
     model_author: string[]
+    _title: string[]
+    _brief: string[]
   }
   resource_path: string
 }

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -38,6 +38,10 @@ export interface IndexSearchResult {
   term: string
 }
 
+export interface SearchQueryResponse {
+  results: SearchResult[]
+}
+
 export interface TextSegment {
   text: string
   highlighted: boolean

--- a/src/utils/search.test.ts
+++ b/src/utils/search.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import { exposures, workspaces } from '@/mocks/search'
-import { filterItemsByQuery, highlightTokens, isValidTerm, normaliseSearchText } from './search'
+import {
+  buildQuerySearchQuery,
+  filterItemsByQuery,
+  highlightTokens,
+  isValidTerm,
+  normaliseSearchText,
+  parseIndexFilterFromQuery,
+  parseQueryFiltersFromQuery,
+} from './search'
 
 describe('filterItemsByQuery', () => {
   it('returns filtered workspace results by search text', () => {
@@ -206,5 +214,121 @@ describe('highlightTokens', () => {
   it('returns non-highlighted whole text when no token matches', () => {
     const segments = highlightTokens('Yasuhara', ['noble'])
     expect(segments).toEqual([{ text: 'Yasuhara', highlighted: false }])
+  })
+})
+
+describe('parseIndexFilterFromQuery', () => {
+  it('returns a filter for a valid kind/term pair', () => {
+    const filter = parseIndexFilterFromQuery({ kind: 'model_author', term: 'Noble' })
+    expect(filter).toEqual({ kind: 'model_author', term: 'Noble' })
+  })
+
+  it('returns null when kind is missing', () => {
+    expect(parseIndexFilterFromQuery({ term: 'Noble' })).toBeNull()
+  })
+
+  it('returns null when term is missing', () => {
+    expect(parseIndexFilterFromQuery({ kind: 'model_author' })).toBeNull()
+  })
+
+  it('returns null for whitespace-only kind or term', () => {
+    expect(parseIndexFilterFromQuery({ kind: '   ', term: 'Noble' })).toBeNull()
+    expect(parseIndexFilterFromQuery({ kind: 'model_author', term: '   ' })).toBeNull()
+  })
+
+  it('ignores array values for kind and term', () => {
+    const filter = parseIndexFilterFromQuery({
+      kind: ['model_author', 'cellml_keyword'],
+      term: ['Noble', 'cardiac'],
+    })
+    expect(filter).toBeNull()
+  })
+})
+
+describe('parseQueryFiltersFromQuery', () => {
+  const knownKinds = ['model_author', 'cellml_keyword', 'citation_author_family_name']
+
+  it('parses a single flat filter param', () => {
+    const filters = parseQueryFiltersFromQuery({ model_author: 'Noble' }, knownKinds)
+    expect(filters).toEqual([{ kind: 'model_author', term: 'Noble' }])
+  })
+
+  it('parses multiple different kind params', () => {
+    const filters = parseQueryFiltersFromQuery(
+      { model_author: 'Noble', cellml_keyword: 'cardiac' },
+      knownKinds,
+    )
+    expect(filters).toEqual([
+      { kind: 'model_author', term: 'Noble' },
+      { kind: 'cellml_keyword', term: 'cardiac' },
+    ])
+  })
+
+  it('parses repeated values for the same kind', () => {
+    const filters = parseQueryFiltersFromQuery(
+      { cellml_keyword: ['cardiac', 'electrophysiology'] },
+      knownKinds,
+    )
+    expect(filters).toEqual([
+      { kind: 'cellml_keyword', term: 'cardiac' },
+      { kind: 'cellml_keyword', term: 'electrophysiology' },
+    ])
+  })
+
+  it('ignores unknown param keys', () => {
+    const filters = parseQueryFiltersFromQuery(
+      { model_author: 'Noble', unknown_kind: 'foo' },
+      knownKinds,
+    )
+    expect(filters).toEqual([{ kind: 'model_author', term: 'Noble' }])
+  })
+
+  it('filters out whitespace-only terms', () => {
+    const filters = parseQueryFiltersFromQuery(
+      { model_author: '   ', cellml_keyword: 'cardiac' },
+      knownKinds,
+    )
+    expect(filters).toEqual([{ kind: 'cellml_keyword', term: 'cardiac' }])
+  })
+
+  it('returns empty array when no known kind params are present', () => {
+    const filters = parseQueryFiltersFromQuery({ query: 'heart', sort: 'relevance' }, knownKinds)
+    expect(filters).toEqual([])
+  })
+})
+
+describe('buildQuerySearchQuery', () => {
+  it('builds a query-only URL', () => {
+    const result = buildQuerySearchQuery('heart', [], {})
+    expect(result).toEqual({ query: 'heart' })
+  })
+
+  it('builds a URL with flat filter params', () => {
+    const result = buildQuerySearchQuery(
+      'heart',
+      [
+        { kind: 'cellml_keyword', term: 'cardiac' },
+        { kind: 'model_author', term: 'Noble' },
+      ],
+      {},
+    )
+    expect(result).toEqual({ query: 'heart', cellml_keyword: 'cardiac', model_author: 'Noble' })
+  })
+
+  it('builds repeated params for the same kind', () => {
+    const result = buildQuerySearchQuery(
+      '',
+      [
+        { kind: 'cellml_keyword', term: 'cardiac' },
+        { kind: 'cellml_keyword', term: 'electrophysiology' },
+      ],
+      {},
+    )
+    expect(result).toEqual({ cellml_keyword: ['cardiac', 'electrophysiology'] })
+  })
+
+  it('omits whitespace-only query text', () => {
+    const result = buildQuerySearchQuery('   ', [], {})
+    expect(result).not.toHaveProperty('query')
   })
 })

--- a/src/utils/search.test.ts
+++ b/src/utils/search.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import { exposures, workspaces } from '@/mocks/search'
 import {
-  buildSearchQuery,
   buildQuerySearchQuery,
+  buildSearchQuery,
   filterItemsByQuery,
   highlightTokens,
   isValidTerm,

--- a/src/utils/search.test.ts
+++ b/src/utils/search.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import { exposures, workspaces } from '@/mocks/search'
 import {
+  buildSearchQuery,
   buildQuerySearchQuery,
   filterItemsByQuery,
   highlightTokens,
   isValidTerm,
   normaliseSearchText,
-  parseIndexFilterFromQuery,
   parseQueryFiltersFromQuery,
 } from './search'
 
@@ -217,34 +217,6 @@ describe('highlightTokens', () => {
   })
 })
 
-describe('parseIndexFilterFromQuery', () => {
-  it('returns a filter for a valid kind/term pair', () => {
-    const filter = parseIndexFilterFromQuery({ kind: 'model_author', term: 'Noble' })
-    expect(filter).toEqual({ kind: 'model_author', term: 'Noble' })
-  })
-
-  it('returns null when kind is missing', () => {
-    expect(parseIndexFilterFromQuery({ term: 'Noble' })).toBeNull()
-  })
-
-  it('returns null when term is missing', () => {
-    expect(parseIndexFilterFromQuery({ kind: 'model_author' })).toBeNull()
-  })
-
-  it('returns null for whitespace-only kind or term', () => {
-    expect(parseIndexFilterFromQuery({ kind: '   ', term: 'Noble' })).toBeNull()
-    expect(parseIndexFilterFromQuery({ kind: 'model_author', term: '   ' })).toBeNull()
-  })
-
-  it('ignores array values for kind and term', () => {
-    const filter = parseIndexFilterFromQuery({
-      kind: ['model_author', 'cellml_keyword'],
-      term: ['Noble', 'cardiac'],
-    })
-    expect(filter).toBeNull()
-  })
-})
-
 describe('parseQueryFiltersFromQuery', () => {
   const knownKinds = ['model_author', 'cellml_keyword', 'citation_author_family_name']
 
@@ -295,6 +267,26 @@ describe('parseQueryFiltersFromQuery', () => {
     const filters = parseQueryFiltersFromQuery({ query: 'heart', sort: 'relevance' }, knownKinds)
     expect(filters).toEqual([])
   })
+
+  it('ignores legacy kind/term params', () => {
+    const filters = parseQueryFiltersFromQuery(
+      { kind: 'model_author', term: 'Noble', model_author: 'Noble' },
+      knownKinds,
+    )
+    expect(filters).toEqual([{ kind: 'model_author', term: 'Noble' }])
+  })
+})
+
+describe('buildSearchQuery', () => {
+  it('builds a single-filter flat query', () => {
+    const result = buildSearchQuery('cellml_keyword', 'cardiac', {})
+    expect(result).toEqual({ cellml_keyword: 'cardiac' })
+  })
+
+  it('preserves valid non-default sort option', () => {
+    const result = buildSearchQuery('cellml_keyword', 'cardiac', { sort: 'date-desc' })
+    expect(result).toEqual({ cellml_keyword: 'cardiac', sort: 'date-desc' })
+  })
 })
 
 describe('buildQuerySearchQuery', () => {
@@ -330,5 +322,18 @@ describe('buildQuerySearchQuery', () => {
   it('omits whitespace-only query text', () => {
     const result = buildQuerySearchQuery('   ', [], {})
     expect(result).not.toHaveProperty('query')
+  })
+
+  it('omits invalid filters with empty kind or term', () => {
+    const result = buildQuerySearchQuery(
+      '',
+      [
+        { kind: 'cellml_keyword', term: 'cardiac' },
+        { kind: '   ', term: 'ignored' },
+        { kind: 'model_author', term: '   ' },
+      ],
+      {},
+    )
+    expect(result).toEqual({ cellml_keyword: 'cardiac' })
   })
 })

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -31,25 +31,15 @@ export const normaliseSearchText = (text: string): string => {
 }
 
 /**
- * Builds a /search query and preserves the current sort option when it is valid.
+ * Builds a /search query for a single filter in flat format and preserves the
+ * current sort option when it is valid.
  */
 export const buildSearchQuery = (
   kind: string,
   term: string,
   currentQuery: LocationQuery,
 ): LocationQueryRaw => {
-  const query: LocationQueryRaw = { kind, term }
-  const sortQuery = currentQuery.sort
-
-  if (
-    typeof sortQuery === 'string' &&
-    isValidSortOption(sortQuery) &&
-    sortQuery !== DEFAULT_SORT_OPTION
-  ) {
-    query.sort = sortQuery
-  }
-
-  return query
+  return buildQuerySearchQuery('', [{ kind, term }], currentQuery)
 }
 
 export const buildQuerySearchQuery = (
@@ -65,9 +55,13 @@ export const buildQuerySearchQuery = (
 
   const termsByKind = new Map<string, string[]>()
   for (const filter of filters) {
-    const terms = termsByKind.get(filter.kind) ?? []
-    terms.push(filter.term)
-    termsByKind.set(filter.kind, terms)
+    const normalisedKind = filter.kind.trim()
+    const normalisedTerm = filter.term.trim()
+    if (!normalisedKind || !normalisedTerm) continue
+
+    const terms = termsByKind.get(normalisedKind) ?? []
+    terms.push(normalisedTerm)
+    termsByKind.set(normalisedKind, terms)
   }
 
   for (const [kind, terms] of termsByKind) {
@@ -96,20 +90,6 @@ const queryParamToStringArray = (value: LocationQuery[string]): string[] => {
   }
 
   return []
-}
-
-/**
- * Parses the single kind/term pair used for index API (api/index) searches.
- */
-export const parseIndexFilterFromQuery = (query: LocationQuery): SearchFilter | null => {
-  const kind = typeof query.kind === 'string' ? query.kind.trim() : ''
-  const term = typeof query.term === 'string' ? query.term.trim() : ''
-
-  if (kind && term) {
-    return { kind, term }
-  }
-
-  return null
 }
 
 /**

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -53,6 +53,28 @@ export const buildSearchQuery = (
 }
 
 /**
+ * Builds a /search free-text query and preserves the current sort option
+ * when it is valid.
+ */
+export const buildQuerySearchQuery = (
+  queryText: string,
+  currentQuery: LocationQuery,
+): LocationQueryRaw => {
+  const query: LocationQueryRaw = { query: queryText }
+  const sortQuery = currentQuery.sort
+
+  if (
+    typeof sortQuery === 'string' &&
+    isValidSortOption(sortQuery) &&
+    sortQuery !== DEFAULT_SORT_OPTION
+  ) {
+    query.sort = sortQuery
+  }
+
+  return query
+}
+
+/**
  * Splits `original` into segments marking which parts match any of the given
  * `tokens`.
  *

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,6 +1,6 @@
 import type { LocationQuery, LocationQueryRaw } from 'vue-router'
 import type { SortableEntity } from '@/types/common'
-import type { QueryFilterOptions, TextSegment } from '@/types/search'
+import type { QueryFilterOptions, SearchFilter, TextSegment } from '@/types/search'
 import { DEFAULT_SORT_OPTION, isValidSortOption } from '@/utils/sort'
 
 /**
@@ -52,17 +52,29 @@ export const buildSearchQuery = (
   return query
 }
 
-/**
- * Builds a /search free-text query and preserves the current sort option
- * when it is valid.
- */
 export const buildQuerySearchQuery = (
   queryText: string,
+  filters: SearchFilter[],
   currentQuery: LocationQuery,
 ): LocationQueryRaw => {
-  const query: LocationQueryRaw = { query: queryText }
-  const sortQuery = currentQuery.sort
+  const query: LocationQueryRaw = {}
 
+  if (queryText.trim()) {
+    query.query = queryText
+  }
+
+  const termsByKind = new Map<string, string[]>()
+  for (const filter of filters) {
+    const terms = termsByKind.get(filter.kind) ?? []
+    terms.push(filter.term)
+    termsByKind.set(filter.kind, terms)
+  }
+
+  for (const [kind, terms] of termsByKind) {
+    query[kind] = terms.length === 1 ? (terms[0] as string) : terms
+  }
+
+  const sortQuery = currentQuery.sort
   if (
     typeof sortQuery === 'string' &&
     isValidSortOption(sortQuery) &&
@@ -72,6 +84,53 @@ export const buildQuerySearchQuery = (
   }
 
   return query
+}
+
+const queryParamToStringArray = (value: LocationQuery[string]): string[] => {
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string')
+  }
+
+  if (typeof value === 'string') {
+    return [value]
+  }
+
+  return []
+}
+
+/**
+ * Parses the single kind/term pair used for index API (api/index) searches.
+ */
+export const parseIndexFilterFromQuery = (query: LocationQuery): SearchFilter | null => {
+  const kind = typeof query.kind === 'string' ? query.kind.trim() : ''
+  const term = typeof query.term === 'string' ? query.term.trim() : ''
+
+  if (kind && term) {
+    return { kind, term }
+  }
+
+  return null
+}
+
+/**
+ * Parses flat kind-named filter params used for search API (api/search) queries.
+ * e.g. ?cellml_keyword=cardiac&model_author=Noble
+ */
+export const parseQueryFiltersFromQuery = (
+  query: LocationQuery,
+  knownKinds: readonly string[],
+): SearchFilter[] => {
+  const filters: SearchFilter[] = []
+
+  for (const kind of knownKinds) {
+    for (const term of queryParamToStringArray(query[kind])) {
+      if (term.trim()) {
+        filters.push({ kind, term: term.trim() })
+      }
+    }
+  }
+
+  return filters
 }
 
 /**

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -48,9 +48,10 @@ export const buildQuerySearchQuery = (
   currentQuery: LocationQuery,
 ): LocationQueryRaw => {
   const query: LocationQueryRaw = {}
+  const trimmedQueryText = queryText.trim()
 
-  if (queryText.trim()) {
-    query.query = queryText
+  if (trimmedQueryText) {
+    query.query = trimmedQueryText
   }
 
   const termsByKind = new Map<string, string[]>()


### PR DESCRIPTION
The new query text search API is available now, and I've implemented it here. The following are notable changes after adding the query search.
- A new query search for any text is available. https://akhuoa.github.io/pmrapp-frontend/search?query=mnt+1975

- "Press Enter to search" is added in the suggestions area when there are no matching keywords or authors found.
  <p><img width="400"  alt="image" src="https://github.com/user-attachments/assets/915e79ca-a3f3-4ef2-a6b1-dea02250bcc1" /></p>

- The help text in the search suggestion overlay is updated, and suggestion category items are limited to `10` items max. 
  <table><tr><th>Before</th><th>After</th></tr><tr><td><img width="918" height="622" alt="image" src="https://github.com/user-attachments/assets/976bf8da-8397-462b-abba-a59b7d89c85b" /></td><td><img width="909" height="587" alt="image" src="https://github.com/user-attachments/assets/c6e97f62-f153-44e3-bbee-70e26bbf7de7" /></td></tr></table>

- The new "brief" text with highlighted `mark` is shown in search results. https://akhuoa.github.io/pmrapp-frontend/search?query=heart

- The URL queries are updated from `kind=value&term=value` to `kind=term`. This is to support multiple search terms, such as `cellml_keyword=actin&cellml_keyword=heart`. Example - https://akhuoa.github.io/pmrapp-frontend/search?query=cor&cellml_keyword=actin&cellml_keyword=heart&citation_author_family_name=Rice. _(Currently, there is no entry for users to perform multiple keyword searching. It will be available in next feture.)_
