### PR TITLE
Remove double nested quotes and refactor

### DIFF
--- a/src/components/atoms/SearchEnterHint.vue
+++ b/src/components/atoms/SearchEnterHint.vue
@@ -6,6 +6,6 @@ withDefaults(defineProps<{ query: string; suffix?: string }>(), { suffix: '' })
 
 <template>
   Press <Keycap>Enter</Keycap> to search for
-  <span class="text-gray-700 dark:text-gray-200 font-semibold">"{{ query }}"</span>
+  <span class="text-gray-700 dark:text-gray-200 font-semibold">{{ query }}</span>
   anywhere in the repository{{ suffix }}.
 </template>

--- a/src/components/atoms/SearchEnterHint.vue
+++ b/src/components/atoms/SearchEnterHint.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import Keycap from '@/components/atoms/Keycap.vue'
+import { formatSearchKey } from '@/utils/format'
 
 withDefaults(defineProps<{ query: string; suffix?: string }>(), { suffix: '' })
 </script>
 
 <template>
   Press <Keycap>Enter</Keycap> to search for
-  <span class="text-gray-700 dark:text-gray-200 font-semibold"><em>{{ query }}</em></span>
+  <span v-html="formatSearchKey(query)"></span>
   anywhere in the repository{{ suffix }}.
 </template>

--- a/src/components/atoms/SearchEnterHint.vue
+++ b/src/components/atoms/SearchEnterHint.vue
@@ -6,6 +6,6 @@ withDefaults(defineProps<{ query: string; suffix?: string }>(), { suffix: '' })
 
 <template>
   Press <Keycap>Enter</Keycap> to search for
-  <span class="text-gray-700 dark:text-gray-200 font-semibold">{{ query }}</span>
+  <span class="text-gray-700 dark:text-gray-200 font-semibold"><em>{{ query }}</em></span>
   anywhere in the repository{{ suffix }}.
 </template>

--- a/src/components/atoms/SearchResultsMessage.vue
+++ b/src/components/atoms/SearchResultsMessage.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { SEARCH_KIND_LABEL_MAP, SEARCH_KIND_LABEL_SINGULAR_MAP } from '@/constants/search'
+import type { SearchFilter, SearchResult } from '@/types/search'
+import { formatNumber } from '@/utils/format'
+
+interface Props {
+  results: SearchResult[]
+  isLoading: boolean
+  error: string | null
+  term: string
+  query?: string
+  filters?: SearchFilter[]
+}
+
+const props = defineProps<Props>()
+
+const resultsCount = computed(() => props.results.length)
+
+const hasResults = computed(() => resultsCount.value > 0)
+
+const hasActiveSearch = computed(() => {
+  return !!(props.query?.trim() || props.filters?.length || props.term.trim())
+})
+
+const activeFilters = computed(() => props.filters ?? [])
+
+const groupedFilters = computed(() => {
+  const groups = new Map<string, string[]>()
+  for (const filter of activeFilters.value) {
+    const terms = groups.get(filter.kind) ?? []
+    terms.push(filter.term)
+    groups.set(filter.kind, terms)
+  }
+  return Array.from(groups.entries()).map(([kind, terms]) => ({ kind, terms }))
+})
+</script>
+
+<template>
+  <p class="mb-4" v-if="!isLoading && !error">
+    <template v-if="!hasResults && !hasActiveSearch">
+      Perform a search to see results.
+    </template>
+    <template v-else-if="!hasResults">
+      No results for
+      <template v-if="query?.trim()"><strong>{{ query }}</strong></template>
+      <template v-if="query?.trim() && groupedFilters.length"> with </template>
+      <template v-for="(group, gi) in groupedFilters" :key="group.kind">
+        <strong>{{ group.terms.length === 1 ? (SEARCH_KIND_LABEL_SINGULAR_MAP[group.kind] || group.kind) : (SEARCH_KIND_LABEL_MAP[group.kind] || group.kind) }}</strong>:
+        <template v-for="(term, ti) in group.terms" :key="term">
+          <strong>{{ term }}</strong>
+          <template v-if="ti < group.terms.length - 2">, </template>
+          <template v-else-if="ti === group.terms.length - 2"> and </template>
+        </template>
+        <template v-if="gi < groupedFilters.length - 2">, </template>
+        <template v-else-if="gi === groupedFilters.length - 2"> and </template>
+      </template>
+    </template>
+    <template v-else>
+      <strong>{{ resultsCount === 1 ? '1 result' : `${formatNumber(resultsCount)} results` }}</strong>
+      <template v-if="query?.trim()"> for <strong>{{ query }}</strong></template>
+      <template v-if="query?.trim() && groupedFilters.length"> with </template>
+      <template v-else-if="!query?.trim() && groupedFilters.length"> for </template>
+      <template v-for="(group, gi) in groupedFilters" :key="group.kind">
+        <strong>{{ group.terms.length === 1 ? (SEARCH_KIND_LABEL_SINGULAR_MAP[group.kind] || group.kind) : (SEARCH_KIND_LABEL_MAP[group.kind] || group.kind) }}</strong>:
+        <template v-for="(term, ti) in group.terms" :key="term">
+          <strong>{{ term }}</strong>
+          <template v-if="ti < group.terms.length - 2">, </template>
+          <template v-else-if="ti === group.terms.length - 2"> and </template>
+        </template>
+        <template v-if="gi < groupedFilters.length - 2">, </template>
+        <template v-else-if="gi === groupedFilters.length - 2"> and </template>
+      </template>
+    </template>
+  </p>
+</template>

--- a/src/components/atoms/SearchResultsMessage.vue
+++ b/src/components/atoms/SearchResultsMessage.vue
@@ -51,7 +51,7 @@ const formatTerms = (terms: string[]) => {
     .map((term, i) => {
       const comma = i < terms.length - 2 ? ', ' : ''
       const and = i === terms.length - 2 ? ' and ' : ''
-      return `<strong>${term}</strong>${comma}${and}`
+      return `<strong><em>${term}</em></strong>${comma}${and}`
     })
     .join('')
 }
@@ -61,7 +61,7 @@ const formatFiltersHtml = computed(() => {
     .map((group, i) => {
       const groupSeparator = i < groupedFilters.value.length - 2 ? ', ' : ''
       const groupAnd = i === groupedFilters.value.length - 2 ? ' and ' : ''
-      return `<strong>${formatGroupLabel(group)}</strong>: ${formatTerms(group.terms)}${groupSeparator}${groupAnd}`
+      return `<em>${formatGroupLabel(group)}</em>: ${formatTerms(group.terms)}${groupSeparator}${groupAnd}`
     })
     .join('')
 })
@@ -72,7 +72,7 @@ const messageNoResults = computed(() => {
   let message = 'No results for'
 
   if (props.query?.trim()) {
-    message += ` <strong>${props.query}</strong>`
+    message += ` <strong><em>${props.query}</em></strong>`
   }
 
   if (groupedFilters.value.length > 0) {
@@ -89,7 +89,7 @@ const messageWithResults = computed(() => {
   let message = `<strong>${countText}</strong>`
 
   if (props.query?.trim()) {
-    message += ` for <strong>${props.query}</strong>`
+    message += ` for <strong><em>${props.query}</em></strong>`
   }
 
   if (groupedFilters.value.length > 0) {

--- a/src/components/atoms/SearchResultsMessage.vue
+++ b/src/components/atoms/SearchResultsMessage.vue
@@ -41,9 +41,10 @@ const groupedFilters = computed(() => {
 })
 
 const formatGroupLabel = (group: MessageGroup) => {
-  const groupLabel = group.terms.length === 1
-    ? SEARCH_KIND_LABEL_SINGULAR_MAP[group.kind] || group.kind
-    : SEARCH_KIND_LABEL_MAP[group.kind] || group.kind
+  const groupLabel =
+    group.terms.length === 1
+      ? SEARCH_KIND_LABEL_SINGULAR_MAP[group.kind] || group.kind
+      : SEARCH_KIND_LABEL_MAP[group.kind] || group.kind
   return formatKindLabel(groupLabel)
 }
 

--- a/src/components/atoms/SearchResultsMessage.vue
+++ b/src/components/atoms/SearchResultsMessage.vue
@@ -41,9 +41,10 @@ const groupedFilters = computed(() => {
 })
 
 const formatGroupLabel = (group: MessageGroup) => {
-  return group.terms.length === 1
+  const groupLabel = group.terms.length === 1
     ? SEARCH_KIND_LABEL_SINGULAR_MAP[group.kind] || group.kind
     : SEARCH_KIND_LABEL_MAP[group.kind] || group.kind
+  return `<em>${groupLabel}</em>`
 }
 
 const formatTerms = (terms: string[]) => {
@@ -61,7 +62,7 @@ const formatFiltersHtml = computed(() => {
     .map((group, i) => {
       const groupSeparator = i < groupedFilters.value.length - 2 ? ', ' : ''
       const groupAnd = i === groupedFilters.value.length - 2 ? ' and ' : ''
-      return `<em>${formatGroupLabel(group)}</em>: ${formatTerms(group.terms)}${groupSeparator}${groupAnd}`
+      return `${formatGroupLabel(group)}: ${formatTerms(group.terms)}${groupSeparator}${groupAnd}`
     })
     .join('')
 })

--- a/src/components/atoms/SearchResultsMessage.vue
+++ b/src/components/atoms/SearchResultsMessage.vue
@@ -13,6 +13,11 @@ interface Props {
   filters?: SearchFilter[]
 }
 
+interface MessageGroup {
+  kind: string
+  terms: string[]
+}
+
 const props = defineProps<Props>()
 
 const resultsCount = computed(() => props.results.length)
@@ -34,43 +39,75 @@ const groupedFilters = computed(() => {
   }
   return Array.from(groups.entries()).map(([kind, terms]) => ({ kind, terms }))
 })
+
+const formatGroupLabel = (group: MessageGroup) => {
+  return group.terms.length === 1
+    ? SEARCH_KIND_LABEL_SINGULAR_MAP[group.kind] || group.kind
+    : SEARCH_KIND_LABEL_MAP[group.kind] || group.kind
+}
+
+const formatTerms = (terms: string[]) => {
+  return terms.map((term, ti) => {
+    const comma = ti < terms.length - 2 ? ', ' : ''
+    const and = ti === terms.length - 2 ? ' and ' : ''
+    return `<strong>${term}</strong>${comma}${and}`
+  }).join('')
+}
+
+const formatFiltersHtml = computed(() => {
+  return groupedFilters.value.map((group, gi) => {
+    const groupSeparator = gi < groupedFilters.value.length - 2 ? ', ' : ''
+    const groupAnd = gi === groupedFilters.value.length - 2 ? ' and ' : ''
+    return `<strong>${formatGroupLabel(group)}</strong>: ${formatTerms(group.terms)}${groupSeparator}${groupAnd}`
+  }).join('')
+})
+
+const messageNoSearch = 'Perform a search to see results.'
+
+const messageNoResults = computed(() => {
+  let message = 'No results for'
+
+  if (props.query?.trim()) {
+    message += ` <strong>${props.query}</strong>`
+  }
+
+  if (groupedFilters.value.length > 0) {
+    message += props.query?.trim() ? ' with ' : ' '
+    message += formatFiltersHtml.value
+  }
+
+  return message
+})
+
+const messageWithResults = computed(() => {
+  const countText = resultsCount.value === 1 ? '1 result' : `${formatNumber(resultsCount.value)} results`
+  let message = `<strong>${countText}</strong>`
+
+  if (props.query?.trim()) {
+    message += ` for <strong>${props.query}</strong>`
+  }
+
+  if (groupedFilters.value.length > 0) {
+    message += props.query?.trim() ? ' with ' : ' for '
+    message += formatFiltersHtml.value
+  }
+
+  return message
+})
 </script>
 
 <template>
   <p class="mb-4" v-if="!isLoading && !error">
     <template v-if="!hasResults && !hasActiveSearch">
-      Perform a search to see results.
+      {{ messageNoSearch }}
     </template>
+
     <template v-else-if="!hasResults">
-      No results for
-      <template v-if="query?.trim()"><strong>{{ query }}</strong></template>
-      <template v-if="query?.trim() && groupedFilters.length"> with </template>
-      <template v-for="(group, gi) in groupedFilters" :key="group.kind">
-        <strong>{{ group.terms.length === 1 ? (SEARCH_KIND_LABEL_SINGULAR_MAP[group.kind] || group.kind) : (SEARCH_KIND_LABEL_MAP[group.kind] || group.kind) }}</strong>:
-        <template v-for="(term, ti) in group.terms" :key="term">
-          <strong>{{ term }}</strong>
-          <template v-if="ti < group.terms.length - 2">, </template>
-          <template v-else-if="ti === group.terms.length - 2"> and </template>
-        </template>
-        <template v-if="gi < groupedFilters.length - 2">, </template>
-        <template v-else-if="gi === groupedFilters.length - 2"> and </template>
-      </template>
+      <span v-html="messageNoResults"></span>
     </template>
+
     <template v-else>
-      <strong>{{ resultsCount === 1 ? '1 result' : `${formatNumber(resultsCount)} results` }}</strong>
-      <template v-if="query?.trim()"> for <strong>{{ query }}</strong></template>
-      <template v-if="query?.trim() && groupedFilters.length"> with </template>
-      <template v-else-if="!query?.trim() && groupedFilters.length"> for </template>
-      <template v-for="(group, gi) in groupedFilters" :key="group.kind">
-        <strong>{{ group.terms.length === 1 ? (SEARCH_KIND_LABEL_SINGULAR_MAP[group.kind] || group.kind) : (SEARCH_KIND_LABEL_MAP[group.kind] || group.kind) }}</strong>:
-        <template v-for="(term, ti) in group.terms" :key="term">
-          <strong>{{ term }}</strong>
-          <template v-if="ti < group.terms.length - 2">, </template>
-          <template v-else-if="ti === group.terms.length - 2"> and </template>
-        </template>
-        <template v-if="gi < groupedFilters.length - 2">, </template>
-        <template v-else-if="gi === groupedFilters.length - 2"> and </template>
-      </template>
+      <span v-html="messageWithResults"></span>
     </template>
   </p>
 </template>

--- a/src/components/atoms/SearchResultsMessage.vue
+++ b/src/components/atoms/SearchResultsMessage.vue
@@ -47,19 +47,23 @@ const formatGroupLabel = (group: MessageGroup) => {
 }
 
 const formatTerms = (terms: string[]) => {
-  return terms.map((term, ti) => {
-    const comma = ti < terms.length - 2 ? ', ' : ''
-    const and = ti === terms.length - 2 ? ' and ' : ''
-    return `<strong>${term}</strong>${comma}${and}`
-  }).join('')
+  return terms
+    .map((term, ti) => {
+      const comma = ti < terms.length - 2 ? ', ' : ''
+      const and = ti === terms.length - 2 ? ' and ' : ''
+      return `<strong>${term}</strong>${comma}${and}`
+    })
+    .join('')
 }
 
 const formatFiltersHtml = computed(() => {
-  return groupedFilters.value.map((group, gi) => {
-    const groupSeparator = gi < groupedFilters.value.length - 2 ? ', ' : ''
-    const groupAnd = gi === groupedFilters.value.length - 2 ? ' and ' : ''
-    return `<strong>${formatGroupLabel(group)}</strong>: ${formatTerms(group.terms)}${groupSeparator}${groupAnd}`
-  }).join('')
+  return groupedFilters.value
+    .map((group, gi) => {
+      const groupSeparator = gi < groupedFilters.value.length - 2 ? ', ' : ''
+      const groupAnd = gi === groupedFilters.value.length - 2 ? ' and ' : ''
+      return `<strong>${formatGroupLabel(group)}</strong>: ${formatTerms(group.terms)}${groupSeparator}${groupAnd}`
+    })
+    .join('')
 })
 
 const messageNoSearch = 'Perform a search to see results.'
@@ -80,7 +84,8 @@ const messageNoResults = computed(() => {
 })
 
 const messageWithResults = computed(() => {
-  const countText = resultsCount.value === 1 ? '1 result' : `${formatNumber(resultsCount.value)} results`
+  const countText =
+    resultsCount.value === 1 ? '1 result' : `${formatNumber(resultsCount.value)} results`
   let message = `<strong>${countText}</strong>`
 
   if (props.query?.trim()) {

--- a/src/components/atoms/SearchResultsMessage.vue
+++ b/src/components/atoms/SearchResultsMessage.vue
@@ -48,9 +48,9 @@ const formatGroupLabel = (group: MessageGroup) => {
 
 const formatTerms = (terms: string[]) => {
   return terms
-    .map((term, ti) => {
-      const comma = ti < terms.length - 2 ? ', ' : ''
-      const and = ti === terms.length - 2 ? ' and ' : ''
+    .map((term, i) => {
+      const comma = i < terms.length - 2 ? ', ' : ''
+      const and = i === terms.length - 2 ? ' and ' : ''
       return `<strong>${term}</strong>${comma}${and}`
     })
     .join('')
@@ -58,9 +58,9 @@ const formatTerms = (terms: string[]) => {
 
 const formatFiltersHtml = computed(() => {
   return groupedFilters.value
-    .map((group, gi) => {
-      const groupSeparator = gi < groupedFilters.value.length - 2 ? ', ' : ''
-      const groupAnd = gi === groupedFilters.value.length - 2 ? ' and ' : ''
+    .map((group, i) => {
+      const groupSeparator = i < groupedFilters.value.length - 2 ? ', ' : ''
+      const groupAnd = i === groupedFilters.value.length - 2 ? ' and ' : ''
       return `<strong>${formatGroupLabel(group)}</strong>: ${formatTerms(group.terms)}${groupSeparator}${groupAnd}`
     })
     .join('')

--- a/src/components/atoms/SearchResultsMessage.vue
+++ b/src/components/atoms/SearchResultsMessage.vue
@@ -2,7 +2,7 @@
 import { computed } from 'vue'
 import { SEARCH_KIND_LABEL_MAP, SEARCH_KIND_LABEL_SINGULAR_MAP } from '@/constants/search'
 import type { SearchFilter, SearchResult } from '@/types/search'
-import { formatNumber } from '@/utils/format'
+import { formatKindLabel, formatNumber, formatSearchKey, formatTermKey } from '@/utils/format'
 
 interface Props {
   results: SearchResult[]
@@ -39,18 +39,6 @@ const groupedFilters = computed(() => {
   }
   return Array.from(groups.entries()).map(([kind, terms]) => ({ kind, terms }))
 })
-
-const formatSearchKey = (key: string): string => {
-  return `<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>${key}</em></span>`
-}
-
-const formatTermKey = (key: string): string => {
-  return `<span class="text-gray-700 dark:text-gray-200 font-semibold">${key}</span>`
-}
-
-const formatKindLabel = (label: string): string => {
-  return `<em class="text-gray-600 dark:text-gray-300">${label}</em>`
-}
 
 const formatGroupLabel = (group: MessageGroup) => {
   const groupLabel = group.terms.length === 1

--- a/src/components/atoms/SearchResultsMessage.vue
+++ b/src/components/atoms/SearchResultsMessage.vue
@@ -40,11 +40,23 @@ const groupedFilters = computed(() => {
   return Array.from(groups.entries()).map(([kind, terms]) => ({ kind, terms }))
 })
 
+const formatSearchKey = (key: string): string => {
+  return `<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>${key}</em></span>`
+}
+
+const formatTermKey = (key: string): string => {
+  return `<span class="text-gray-700 dark:text-gray-200 font-semibold">${key}</span>`
+}
+
+const formatKindLabel = (label: string): string => {
+  return `<em class="text-gray-600 dark:text-gray-300">${label}</em>`
+}
+
 const formatGroupLabel = (group: MessageGroup) => {
   const groupLabel = group.terms.length === 1
     ? SEARCH_KIND_LABEL_SINGULAR_MAP[group.kind] || group.kind
     : SEARCH_KIND_LABEL_MAP[group.kind] || group.kind
-  return `<em>${groupLabel}</em>`
+  return formatKindLabel(groupLabel)
 }
 
 const formatTerms = (terms: string[]) => {
@@ -52,7 +64,7 @@ const formatTerms = (terms: string[]) => {
     .map((term, i) => {
       const comma = i < terms.length - 2 ? ', ' : ''
       const and = i === terms.length - 2 ? ' and ' : ''
-      return `<strong><em>${term}</em></strong>${comma}${and}`
+      return `${formatTermKey(term)}${comma}${and}`
     })
     .join('')
 }
@@ -73,7 +85,7 @@ const messageNoResults = computed(() => {
   let message = 'No results for'
 
   if (props.query?.trim()) {
-    message += ` <strong><em>${props.query}</em></strong>`
+    message += ` ${formatSearchKey(props.query)}`
   }
 
   if (groupedFilters.value.length > 0) {
@@ -87,10 +99,10 @@ const messageNoResults = computed(() => {
 const messageWithResults = computed(() => {
   const countText =
     resultsCount.value === 1 ? '1 result' : `${formatNumber(resultsCount.value)} results`
-  let message = `<strong>${countText}</strong>`
+  let message = `<strong class="text-gray-700 dark:text-gray-200">${countText}</strong>`
 
   if (props.query?.trim()) {
-    message += ` for <strong><em>${props.query}</em></strong>`
+    message += ` for ${formatSearchKey(props.query)}`
   }
 
   if (groupedFilters.value.length > 0) {
@@ -103,7 +115,7 @@ const messageWithResults = computed(() => {
 </script>
 
 <template>
-  <p class="mb-4" v-if="!isLoading && !error">
+  <p class="mb-4 text-gray-500 dark:text-gray-400" v-if="!isLoading && !error">
     <template v-if="!hasResults && !hasActiveSearch">
       {{ messageNoSearch }}
     </template>

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -407,7 +407,7 @@ defineExpose({
         <div v-else-if="!hasResults" class="p-4">
           <p class="text-gray-500 dark:text-gray-400 text-sm">
             No authors or keywords found for
-            <span class="text-gray-700 dark:text-gray-200 font-semibold">"{{ searchInput }}"</span>.
+            <span class="text-gray-700 dark:text-gray-200 font-semibold">{{ searchInput }}</span>.
             <SearchEnterHint :query="searchInput" />
           </p>
         </div>

--- a/src/components/molecules/SearchInput.vue
+++ b/src/components/molecules/SearchInput.vue
@@ -17,7 +17,7 @@ import { useExposureStore } from '@/stores/exposure'
 import { useSearchStore } from '@/stores/search'
 import { useWorkspaceStore } from '@/stores/workspace'
 import type { SortableEntity } from '@/types/common'
-import { formatNumber } from '@/utils/format'
+import { formatNumber, formatSearchKey } from '@/utils/format'
 import { filterItemsByQuery, isValidTerm, normaliseSearchText } from '@/utils/search'
 
 const props = defineProps<{
@@ -407,7 +407,7 @@ defineExpose({
         <div v-else-if="!hasResults" class="p-4">
           <p class="text-gray-500 dark:text-gray-400 text-sm">
             No authors or keywords found for
-            <span class="text-gray-700 dark:text-gray-200 font-semibold">{{ searchInput }}</span>.
+            <span v-html="formatSearchKey(searchInput)"></span>.
             <SearchEnterHint :query="searchInput" />
           </p>
         </div>

--- a/src/components/molecules/SearchResults.vue
+++ b/src/components/molecules/SearchResults.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useRoute, useRouter } from 'vue-router'
-import TermButton from '@/components/atoms/TermButton.vue'
 import SearchResultsMessage from '@/components/atoms/SearchResultsMessage.vue'
+import TermButton from '@/components/atoms/TermButton.vue'
 import FileIcon from '@/components/icons/FileIcon.vue'
 import ListContent from '@/components/molecules/ListContent.vue'
 import ListItem from '@/components/molecules/ListItem.vue'

--- a/src/components/molecules/SearchResults.vue
+++ b/src/components/molecules/SearchResults.vue
@@ -89,7 +89,7 @@ const isIdActive = (ids: string[] | undefined) => {
       </template>
       <template v-else>
         <strong>{{ resultsCount === 1 ? '1 result' : `${formatNumber(resultsCount)} results` }}</strong>
-        <template v-if="query?.trim()"> for <strong>"{{ query }}"</strong></template>
+        <template v-if="query?.trim()"> for <strong>{{ query }}</strong></template>
         <template v-if="query?.trim() && groupedFilters.length"> with </template>
         <template v-else-if="!query?.trim() && groupedFilters.length"> for </template>
         <template v-for="(group, gi) in groupedFilters" :key="group.kind">

--- a/src/components/molecules/SearchResults.vue
+++ b/src/components/molecules/SearchResults.vue
@@ -74,12 +74,12 @@ const isIdActive = (ids: string[] | undefined) => {
       </template>
       <template v-else-if="!hasResults">
         No results for
-        <template v-if="query?.trim()"><strong>"{{ query }}"</strong></template>
+        <template v-if="query?.trim()"><strong>{{ query }}</strong></template>
         <template v-if="query?.trim() && groupedFilters.length"> with </template>
         <template v-for="(group, gi) in groupedFilters" :key="group.kind">
           <strong>{{ group.terms.length === 1 ? (SEARCH_KIND_LABEL_SINGULAR_MAP[group.kind] || group.kind) : (SEARCH_KIND_LABEL_MAP[group.kind] || group.kind) }}</strong>:
           <template v-for="(term, ti) in group.terms" :key="term">
-            "<strong>{{ term }}</strong>"
+            <strong>{{ term }}</strong>
             <template v-if="ti < group.terms.length - 2">, </template>
             <template v-else-if="ti === group.terms.length - 2"> and </template>
           </template>
@@ -95,7 +95,7 @@ const isIdActive = (ids: string[] | undefined) => {
         <template v-for="(group, gi) in groupedFilters" :key="group.kind">
           <strong>{{ group.terms.length === 1 ? (SEARCH_KIND_LABEL_SINGULAR_MAP[group.kind] || group.kind) : (SEARCH_KIND_LABEL_MAP[group.kind] || group.kind) }}</strong>:
           <template v-for="(term, ti) in group.terms" :key="term">
-            "<strong>{{ term }}</strong>"
+            <strong>{{ term }}</strong>
             <template v-if="ti < group.terms.length - 2">, </template>
             <template v-else-if="ti === group.terms.length - 2"> and </template>
           </template>

--- a/src/components/molecules/SearchResults.vue
+++ b/src/components/molecules/SearchResults.vue
@@ -1,14 +1,13 @@
 <script setup lang="ts">
-import { computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import TermButton from '@/components/atoms/TermButton.vue'
+import SearchResultsMessage from '@/components/atoms/SearchResultsMessage.vue'
 import FileIcon from '@/components/icons/FileIcon.vue'
 import ListContent from '@/components/molecules/ListContent.vue'
 import ListItem from '@/components/molecules/ListItem.vue'
-import { SEARCH_KIND_LABEL_MAP, SEARCH_KIND_LABEL_SINGULAR_MAP } from '@/constants/search'
 import type { SearchFilter, SearchResult } from '@/types/search'
 import { getExposureIdFromResourcePath } from '@/utils/exposure'
-import { formatDate, formatNumber } from '@/utils/format'
+import { formatDate } from '@/utils/format'
 import { buildSearchQuery, isValidTerm } from '@/utils/search'
 
 interface Props {
@@ -36,30 +35,6 @@ const handleAuthorClick = (kind: string, author: string) => {
   router.push({ path: '/search', query: buildSearchQuery(kind, author, route.query) })
 }
 
-const kindLabel = computed(() => {
-  return SEARCH_KIND_LABEL_MAP[props.kind] || props.kind
-})
-
-const resultsCount = computed(() => props.results.length)
-
-const hasResults = computed(() => resultsCount.value > 0)
-
-const hasActiveSearch = computed(() => {
-  return !!(props.query?.trim() || props.filters?.length || props.term.trim())
-})
-
-const activeFilters = computed(() => props.filters ?? [])
-
-const groupedFilters = computed(() => {
-  const groups = new Map<string, string[]>()
-  for (const filter of activeFilters.value) {
-    const terms = groups.get(filter.kind) ?? []
-    terms.push(filter.term)
-    groups.set(filter.kind, terms)
-  }
-  return Array.from(groups.entries()).map(([kind, terms]) => ({ kind, terms }))
-})
-
 const isIdActive = (ids: string[] | undefined) => {
   if (!ids || props.kind !== 'citation_id') return false
   return ids.some((id) => id.toLowerCase() === props.term.toLowerCase())
@@ -68,42 +43,14 @@ const isIdActive = (ids: string[] | undefined) => {
 
 <template>
   <div>
-    <p class="mb-4" v-if="!isLoading && !error">
-      <template v-if="!hasResults && !hasActiveSearch">
-        Perform a search to see results.
-      </template>
-      <template v-else-if="!hasResults">
-        No results for
-        <template v-if="query?.trim()"><strong>{{ query }}</strong></template>
-        <template v-if="query?.trim() && groupedFilters.length"> with </template>
-        <template v-for="(group, gi) in groupedFilters" :key="group.kind">
-          <strong>{{ group.terms.length === 1 ? (SEARCH_KIND_LABEL_SINGULAR_MAP[group.kind] || group.kind) : (SEARCH_KIND_LABEL_MAP[group.kind] || group.kind) }}</strong>:
-          <template v-for="(term, ti) in group.terms" :key="term">
-            <strong>{{ term }}</strong>
-            <template v-if="ti < group.terms.length - 2">, </template>
-            <template v-else-if="ti === group.terms.length - 2"> and </template>
-          </template>
-          <template v-if="gi < groupedFilters.length - 2">, </template>
-          <template v-else-if="gi === groupedFilters.length - 2"> and </template>
-        </template>
-      </template>
-      <template v-else>
-        <strong>{{ resultsCount === 1 ? '1 result' : `${formatNumber(resultsCount)} results` }}</strong>
-        <template v-if="query?.trim()"> for <strong>{{ query }}</strong></template>
-        <template v-if="query?.trim() && groupedFilters.length"> with </template>
-        <template v-else-if="!query?.trim() && groupedFilters.length"> for </template>
-        <template v-for="(group, gi) in groupedFilters" :key="group.kind">
-          <strong>{{ group.terms.length === 1 ? (SEARCH_KIND_LABEL_SINGULAR_MAP[group.kind] || group.kind) : (SEARCH_KIND_LABEL_MAP[group.kind] || group.kind) }}</strong>:
-          <template v-for="(term, ti) in group.terms" :key="term">
-            <strong>{{ term }}</strong>
-            <template v-if="ti < group.terms.length - 2">, </template>
-            <template v-else-if="ti === group.terms.length - 2"> and </template>
-          </template>
-          <template v-if="gi < groupedFilters.length - 2">, </template>
-          <template v-else-if="gi === groupedFilters.length - 2"> and </template>
-        </template>
-      </template>
-    </p>
+    <SearchResultsMessage
+      :results="results"
+      :is-loading="isLoading"
+      :error="error"
+      :term="term"
+      :query="query"
+      :filters="filters"
+    />
 
     <ListContent
       :items="results"

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -60,19 +60,25 @@ describe('formatSearchKey', () => {
   it('returns formatted search key for normal string', () => {
     const results = formatSearchKey('Cells')
 
-    expect(results).toBe('<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>Cells</em></span>')
+    expect(results).toBe(
+      '<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>Cells</em></span>',
+    )
   })
 
   it('returns formatted and escaped HTML for HTML string', () => {
     const results = formatSearchKey('<h1>Cells</h1>')
 
-    expect(results).toBe('<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>&lt;h1&gt;Cells&lt;/h1&gt;</em></span>')
+    expect(results).toBe(
+      '<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>&lt;h1&gt;Cells&lt;/h1&gt;</em></span>',
+    )
   })
 
   it('returns formatted and escaped HTML for HTML string', () => {
     const results = formatSearchKey('<script>alert("hello")</script>')
 
-    expect(results).toBe('<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>&lt;script&gt;alert(&quot;hello&quot;)&lt;/script&gt;</em></span>')
+    expect(results).toBe(
+      '<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>&lt;script&gt;alert(&quot;hello&quot;)&lt;/script&gt;</em></span>',
+    )
   })
 })
 
@@ -80,7 +86,9 @@ describe('formatTermKey', () => {
   it('returns formatted term key for normal string', () => {
     const results = formatTermKey('Cells')
 
-    expect(results).toBe('<span class="text-gray-700 dark:text-gray-200 font-semibold">Cells</span>')
+    expect(results).toBe(
+      '<span class="text-gray-700 dark:text-gray-200 font-semibold">Cells</span>',
+    )
   })
 })
 

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatNumber,
+  formatDate,
+  formatFileCount,
+  formatSearchKey,
+  formatTermKey,
+  formatKindLabel,
+} from './format'
+
+describe('formatNumber', () => {
+  it('returns formatted number', () => {
+    const results = formatNumber(1234567)
+
+    expect(results).toBe('1,234,567')
+  })
+})
+
+describe('formatDate', () => {
+  it('returns formatted date', () => {
+    const results = formatDate(1704499200)
+
+    expect(results).toBe('6 January 2024')
+  })
+})
+
+describe('formatFileCount', () => {
+  it('returns formatted file count for 1 item', () => {
+    const results = formatFileCount(1)
+
+    expect(results).toBe('1 item')
+  })
+
+  it('returns formatted file count for more than 1', () => {
+    const results = formatFileCount(1234)
+
+    expect(results).toBe('1,234 items')
+  })
+
+  it('returns formatted file count for zero', () => {
+    const results = formatFileCount(0)
+
+    expect(results).toBe('')
+  })
+
+  it('returns formatted file count for undefined', () => {
+    const results = formatFileCount(undefined)
+
+    expect(results).toBe('')
+  })
+
+  it('returns formatted file count for null', () => {
+    const results = formatFileCount(null)
+
+    expect(results).toBe('')
+  })
+})
+
+describe('formatSearchKey', () => {
+  it('returns formatted search key for normal string', () => {
+    const results = formatSearchKey('Cells')
+
+    expect(results).toBe('<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>Cells</em></span>')
+  })
+
+  it('returns formatted and escaped HTML for HTML string', () => {
+    const results = formatSearchKey('<h1>Cells</h1>')
+
+    expect(results).toBe('<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>&lt;h1&gt;Cells&lt;/h1&gt;</em></span>')
+  })
+
+  it('returns formatted and escaped HTML for HTML string', () => {
+    const results = formatSearchKey('<script>alert("hello")</script>')
+
+    expect(results).toBe('<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>&lt;script&gt;alert(&quot;hello&quot;)&lt;/script&gt;</em></span>')
+  })
+})
+
+describe('formatTermKey', () => {
+  it('returns formatted term key for normal string', () => {
+    const results = formatTermKey('Cells')
+
+    expect(results).toBe('<span class="text-gray-700 dark:text-gray-200 font-semibold">Cells</span>')
+  })
+})
+
+describe('formatKindLabel', () => {
+  it('returns formatted kind label for normal string', () => {
+    const results = formatKindLabel('Cells')
+
+    expect(results).toBe('<em class="text-gray-600 dark:text-gray-300">Cells</em>')
+  })
+})

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -61,7 +61,7 @@ describe('formatSearchKey', () => {
     const results = formatSearchKey('Cells')
 
     expect(results).toBe(
-      '<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>Cells</em></span>',
+      '<span class="text-gray-700 dark:text-gray-200 font-semibold">Cells</span>',
     )
   })
 
@@ -69,7 +69,7 @@ describe('formatSearchKey', () => {
     const results = formatSearchKey('<h1>Cells</h1>')
 
     expect(results).toBe(
-      '<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>&lt;h1&gt;Cells&lt;/h1&gt;</em></span>',
+      '<span class="text-gray-700 dark:text-gray-200 font-semibold">&lt;h1&gt;Cells&lt;/h1&gt;</span>',
     )
   })
 
@@ -77,7 +77,7 @@ describe('formatSearchKey', () => {
     const results = formatSearchKey('<script>alert("hello")</script>')
 
     expect(results).toBe(
-      '<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>&lt;script&gt;alert(&quot;hello&quot;)&lt;/script&gt;</em></span>',
+      '<span class="text-gray-700 dark:text-gray-200 font-semibold">&lt;script&gt;alert(&quot;hello&quot;)&lt;/script&gt;</span>',
     )
   })
 })
@@ -96,6 +96,6 @@ describe('formatKindLabel', () => {
   it('returns formatted kind label for normal string', () => {
     const results = formatKindLabel('Cells')
 
-    expect(results).toBe('<em class="text-gray-600 dark:text-gray-300">Cells</em>')
+    expect(results).toBe('<span class="text-gray-600 dark:text-gray-300">Cells</span>')
   })
 })

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -12,7 +12,7 @@ export function formatNumber(num: number): string {
  * Format a Unix timestamp to a readable date string.
  * @param timestamp - Unix timestamp in seconds.
  * @returns Formatted date string (e.g., "5 January 2026").
- * @example formatDate(1704499200) // "5 January 2024".
+ * @example formatDate(1704499200) // "6 January 2024".
  */
 export function formatDate(timestamp: number): string {
   return new Date(timestamp * 1000).toLocaleDateString('en-NZ', {

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -37,14 +37,26 @@ export function formatFileCount(count: number | undefined | null): string {
   return `${formatted} ${count === 1 ? 'item' : 'items'}`
 }
 
-export function formatSearchKey (key: string): string {
-  return `<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>${key}</em></span>`
+const escapeHtml = (value: string): string => {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
 }
 
-export function formatTermKey (key: string): string {
-  return `<span class="text-gray-700 dark:text-gray-200 font-semibold">${key}</span>`
+export function formatSearchKey(key: string): string {
+  const safeKey = escapeHtml(key)
+  return `<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>${safeKey}</em></span>`
 }
 
-export function formatKindLabel (label: string): string {
-  return `<em class="text-gray-600 dark:text-gray-300">${label}</em>`
+export function formatTermKey(key: string): string {
+  const safeKey = escapeHtml(key)
+  return `<span class="text-gray-700 dark:text-gray-200 font-semibold">${safeKey}</span>`
+}
+
+export function formatKindLabel(label: string): string {
+  const safeLabel = escapeHtml(label)
+  return `<em class="text-gray-600 dark:text-gray-300">${safeLabel}</em>`
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -36,3 +36,15 @@ export function formatFileCount(count: number | undefined | null): string {
   const formatted = formatNumber(count)
   return `${formatted} ${count === 1 ? 'item' : 'items'}`
 }
+
+export function formatSearchKey (key: string): string {
+  return `<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>${key}</em></span>`
+}
+
+export function formatTermKey (key: string): string {
+  return `<span class="text-gray-700 dark:text-gray-200 font-semibold">${key}</span>`
+}
+
+export function formatKindLabel (label: string): string {
+  return `<em class="text-gray-600 dark:text-gray-300">${label}</em>`
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -48,7 +48,7 @@ const escapeHtml = (value: string): string => {
 
 export function formatSearchKey(key: string): string {
   const safeKey = escapeHtml(key)
-  return `<span class="text-gray-700 dark:text-gray-200 font-semibold"><em>${safeKey}</em></span>`
+  return `<span class="text-gray-700 dark:text-gray-200 font-semibold">${safeKey}</span>`
 }
 
 export function formatTermKey(key: string): string {
@@ -58,5 +58,5 @@ export function formatTermKey(key: string): string {
 
 export function formatKindLabel(label: string): string {
   const safeLabel = escapeHtml(label)
-  return `<em class="text-gray-600 dark:text-gray-300">${safeLabel}</em>`
+  return `<span class="text-gray-600 dark:text-gray-300">${safeLabel}</span>`
 }


### PR DESCRIPTION
Fixes #183.

This pull request addresses the issue of showing nested double quotes in search results messages for search queries with double quotes.
Additionally, it addresses the issue of too many templates in the search results message by refactoring it into a separate component and using computed properties.

### Examples
- Without double quotes: https://akhuoa.github.io/pmrapp-frontend/search?query=Auckland+Bioengineering+Institute
- With double quotes: https://akhuoa.github.io/pmrapp-frontend/search?query=%22Auckland+Bioengineering+Institute%22