### PR TITLE
Fix exposure detail navigation

### DIFF
--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -431,58 +431,77 @@ const loadInitialView = async () => {
   exposureId.value = exposureInfo.value.exposure?.id
   const exposureFiles = exposureInfo.value.exposure?.files || []
   const filesWithViews = exposureFiles.filter((file) => file.views?.length > 0)
-  let fileWithViews = filesWithViews?.find((file) => file.workspace_file_path.endsWith('.cellml'))
+  const defaultFileWithViews =
+    filesWithViews.find((file) => file.workspace_file_path.endsWith('.cellml')) || filesWithViews[0]
+
+  // Reset per-file state before selecting a new file to avoid stale view content.
+  availableViews.value = []
+  exposureFileId.value = Number.NaN
+  detailHTML.value = ''
+  generatedCode.value = ''
+  generatedCodeFilename.value = ''
+  rawMathsData.value = []
+  metadataJSON.value = {}
+  hasOtherRelatedModels.value = false
+  licenseInfo.value = DEFAULT_LICENSE
+
+  let fileWithViews: (typeof filesWithViews)[number] | undefined = defaultFileWithViews
 
   if (props.file) {
-    fileWithViews = filesWithViews?.find((file) => file.workspace_file_path === props.file)
+    exposureFilePath.value = props.file
+    fileWithViews = filesWithViews.find((file) => file.workspace_file_path === props.file)
+  } else {
+    exposureFilePath.value = defaultFileWithViews?.workspace_file_path || ''
   }
 
-  if (fileWithViews) {
-    availableViews.value = AVAILABLE_VIEWS.filter((view) =>
-      fileWithViews.views.some((v) => v.view_key === view.view_key),
+  if (!fileWithViews) {
+    return
+  }
+
+  availableViews.value = AVAILABLE_VIEWS.filter((view) =>
+    fileWithViews.views.some((v) => v.view_key === view.view_key),
+  )
+  exposureFileId.value = fileWithViews.id
+  exposureFilePath.value = fileWithViews.workspace_file_path
+  exposureId.value = fileWithViews.exposure_id
+
+  const viewEntry = fileWithViews.views.find((v) => v.view_key === 'view')
+  const licenseEntry = fileWithViews.views.find((v) => v.view_key === 'license_citation')
+  const metaEntry = fileWithViews.views.find((v) => v.view_key === 'cellml_metadata')
+
+  // Show metadata onload.
+  if (metaEntry) {
+    await generateMetadata()
+  }
+  await checkOtherRelatedModels()
+
+  if (viewEntry) {
+    detailHTML.value = await exposureStore.getExposureSafeHTML(
+      exposureId.value,
+      viewEntry.exposure_file_id,
+      'view',
+      'index.html',
+      routePath,
     )
-    exposureFileId.value = fileWithViews.id
-    exposureFilePath.value = fileWithViews.workspace_file_path
-    exposureId.value = fileWithViews.exposure_id
+  }
 
-    const viewEntry = fileWithViews.views.find((v) => v.view_key === 'view')
-    const licenseEntry = fileWithViews.views.find((v) => v.view_key === 'license_citation')
-    const metaEntry = fileWithViews.views.find((v) => v.view_key === 'cellml_metadata')
+  if (licenseEntry) {
+    licenseInfo.value = await exposureStore.getExposureSafeHTML(
+      exposureId.value,
+      licenseEntry.exposure_file_id,
+      'license_citation',
+      'license.txt',
+      routePath,
+    )
+  }
 
-    // Show metadata onload.
-    if (metaEntry) {
-      await generateMetadata()
-    }
-    await checkOtherRelatedModels()
+  // Load codegen view with default language.
+  if (props.view === 'cellml_codegen') {
+    await loadCodegenView()
+  }
 
-    if (viewEntry) {
-      detailHTML.value = await exposureStore.getExposureSafeHTML(
-        exposureId.value,
-        viewEntry.exposure_file_id,
-        'view',
-        'index.html',
-        routePath,
-      )
-    }
-
-    if (licenseEntry) {
-      licenseInfo.value = await exposureStore.getExposureSafeHTML(
-        exposureId.value,
-        licenseEntry.exposure_file_id,
-        'license_citation',
-        'license.txt',
-        routePath,
-      )
-    }
-
-    // Load codegen view with default language.
-    if (props.view === 'cellml_codegen') {
-      await loadCodegenView()
-    }
-
-    if (props.view === 'cellml_math') {
-      await generateMath()
-    }
+  if (props.view === 'cellml_math') {
+    await generateMath()
   }
 }
 

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -428,26 +428,30 @@ const checkOtherRelatedModels = async () => {
   }
 }
 
+// Reset all state variables that are specific to a file or view.
+const resetState = () => {
+  availableViews.value = []
+  detailHTML.value = ''
+  exposureFileId.value = Number.NaN
+  exposureFilePath.value = ''
+  generatedCode.value = ''
+  generatedCodeFilename.value = ''
+  hasOtherRelatedModels.value = false
+  licenseInfo.value = DEFAULT_LICENSE
+  metadataJSON.value = {}
+  rawMathsData.value = []
+}
+
 const loadInitialView = async () => {
   if (!exposureInfo.value) return
 
+  // Reset per-file state before selecting a new file to avoid stale view content.
+  resetState()
   exposureId.value = exposureInfo.value.exposure?.id
   const exposureFiles = exposureInfo.value.exposure?.files || []
   const filesWithViews = exposureFiles.filter((file) => file.views?.length > 0)
   const defaultFileWithViews =
     filesWithViews.find((file) => file.workspace_file_path.endsWith('.cellml')) || filesWithViews[0]
-
-  // Reset per-file state before selecting a new file to avoid stale view content.
-  availableViews.value = []
-  exposureFileId.value = Number.NaN
-  detailHTML.value = ''
-  generatedCode.value = ''
-  generatedCodeFilename.value = ''
-  rawMathsData.value = []
-  metadataJSON.value = {}
-  hasOtherRelatedModels.value = false
-  licenseInfo.value = DEFAULT_LICENSE
-
   let fileWithViews: (typeof filesWithViews)[number] | undefined = defaultFileWithViews
 
   if (props.file) {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -169,6 +169,9 @@ const openCORFiles = computed(() => {
   if (!exposureInfo.value) return []
 
   return exposureInfo.value.files.filter((entry) => {
+    if (props.file) {
+      return entry[0] === props.file && isOpenCORFile(entry[0])
+    }
     return isOpenCORFile(entry[0])
   })
 })

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -354,13 +354,16 @@ const generateMetadata = async () => {
 }
 
 const loadDefaultView = async () => {
-  detailHTML.value = await exposureStore.getExposureSafeHTML(
-    exposureId.value,
-    exposureFileId.value,
-    'view',
-    'index.html',
-    routePath,
-  )
+  // Only load the HTML view if we have the necessary exposure ID and file ID.
+  if (exposureId.value && exposureFileId.value) {
+    detailHTML.value = await exposureStore.getExposureSafeHTML(
+      exposureId.value,
+      exposureFileId.value,
+      'view',
+      'index.html',
+      routePath,
+    )
+  }
 }
 
 const loadCodegenView = async () => {
@@ -425,9 +428,9 @@ const checkOtherRelatedModels = async () => {
 const loadInitialView = async () => {
   if (!exposureInfo.value) return
 
-  const filesWithViews = exposureInfo.value.exposure?.files?.filter(
-    (file) => file.views && file.views.length > 0,
-  )
+  exposureId.value = exposureInfo.value.exposure?.id
+  const exposureFiles = exposureInfo.value.exposure?.files || []
+  const filesWithViews = exposureFiles.filter((file) => file.views?.length > 0)
   let fileWithViews = filesWithViews?.find((file) => file.workspace_file_path.endsWith('.cellml'))
 
   if (props.file) {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -103,7 +103,7 @@ const router = createRouter({
       meta: { title: `Exposure Detail – ${title}` },
     },
     {
-      path: '/exposures/:alias/:file',
+      path: '/exposures/:alias/:file(.+)',
       name: 'exposure-file-detail',
       component: ExposureDetailView,
       // biome-ignore format: keep the formatting for readability
@@ -115,7 +115,7 @@ const router = createRouter({
       meta: { title: `Exposure File – ${title}` },
     },
     {
-      path: '/exposures/:alias/:file/:view',
+      path: '/exposures/:alias/:file(.+)/:view',
       name: 'exposure-file-detail-view',
       component: ExposureDetailView,
       // biome-ignore format: keep the formatting for readability

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -103,7 +103,7 @@ const router = createRouter({
       meta: { title: `Exposure Detail – ${title}` },
     },
     {
-      path: '/exposures/:alias/:file(.+)/:view',
+      path: '/exposures/:alias/:file(.+)/:view([^./]+)',
       name: 'exposure-file-detail-view',
       component: ExposureDetailView,
       // biome-ignore format: keep the formatting for readability

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -103,18 +103,6 @@ const router = createRouter({
       meta: { title: `Exposure Detail – ${title}` },
     },
     {
-      path: '/exposures/:alias/:file(.+)',
-      name: 'exposure-file-detail',
-      component: ExposureDetailView,
-      // biome-ignore format: keep the formatting for readability
-      alias: createPluralRouteAliases(
-        '/exposures',
-        exposureAliasBases,
-        exposureFileRouteSuffixes
-      ),
-      meta: { title: `Exposure File – ${title}` },
-    },
-    {
       path: '/exposures/:alias/:file(.+)/:view',
       name: 'exposure-file-detail-view',
       component: ExposureDetailView,
@@ -123,6 +111,18 @@ const router = createRouter({
         '/exposures',
         exposureAliasBases,
         exposureFileViewRouteSuffixes
+      ),
+      meta: { title: `Exposure File – ${title}` },
+    },
+    {
+      path: '/exposures/:alias/:file(.+)',
+      name: 'exposure-file-detail',
+      component: ExposureDetailView,
+      // biome-ignore format: keep the formatting for readability
+      alias: createPluralRouteAliases(
+        '/exposures',
+        exposureAliasBases,
+        exposureFileRouteSuffixes
       ),
       meta: { title: `Exposure File – ${title}` },
     },


### PR DESCRIPTION
Fixes #174.

There are some exposure navigations, which don't have views to load. And they are currently showing as 404 because the router didn't handle the file path with nested folders.

This update fixes the router to handle the nested file view and fixes navigation view loading so that it does not load the API when no views are available. 

### Scenario 1
**Before the fix**
https://physiome.github.io/pmrapp-frontend/exposures/b03/mapclient%20workflow/argon_viewer-previous-docs/document-d60fd870ecc08f293d30237e82f14713.json

**After the fix**
https://akhuoa.github.io/pmrapp-frontend/exposures/b03/mapclient%20workflow/argon_viewer-previous-docs/document-d60fd870ecc08f293d30237e82f14713.json

<br>

### Scenario 2
**Before the fix**
- Step 1: https://physiome.github.io/pmrapp-frontend/exposures/cbf/BG_CaL.cellml
- Step 2: Click `exposure/BG_CaL.png` from the navigation. 
- Step 3: It shows the previous file view.

**After the fix**
- Step 1: https://akhuoa.github.io/pmrapp-frontend/exposures/cbf/BG_CaL.cellml
- Step 2: Click `exposure/BG_CaL.png` from the navigation. 
- Step 3: It shows the empty view.
