### PR TITLE
Update styles in exposure html file view

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -54,8 +54,6 @@
   mark {
     @apply bg-amber-200 dark:bg-amber-400 text-accent;
   }
-
-
 }
 
 :root {

--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -2,6 +2,7 @@
 
 @theme {
   --font-sans: "Lucida Sans Unicode", "Lucida Grande", sans-serif;
+  --font-mono: "Consolas", "Monaco", "Courier New", monospace;
 
   --color-primary: var(--primary);
   --color-primary-fg: var(--primary-fg);
@@ -53,6 +54,8 @@
   mark {
     @apply bg-amber-200 dark:bg-amber-400 text-accent;
   }
+
+
 }
 
 :root {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -931,7 +931,8 @@ onMounted(async () => {
     @apply text-3xl font-bold mt-8 mb-8;
   }
 
-  & :deep(h1:first-child) {
+  & :deep(> h1:first-child),
+  & :deep(> div > h1:first-child) {
     @apply mt-0;
   }
 

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -927,6 +927,14 @@ onMounted(async () => {
     @apply text-link dark:underline dark:decoration-dotted hover:text-link-hover transition;
   }
 
+  & :deep(h1) {
+    @apply text-3xl font-bold mt-8 mb-8;
+  }
+
+  & :deep(h1:first-child) {
+    @apply mt-0;
+  }
+
   & :deep(h2) {
     @apply text-2xl font-semibold mt-0 mb-8;
   }
@@ -969,6 +977,10 @@ onMounted(async () => {
 
   & :deep(table td) {
     @apply align-top text-sm;
+  }
+
+  & :deep(blockquote) {
+    @apply border-l-4 border-gray-300 dark:border-gray-600 pl-4 italic text-gray-600 dark:text-gray-400 my-4;
   }
 }
 

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -983,6 +983,56 @@ onMounted(async () => {
   & :deep(blockquote) {
     @apply border-l-4 border-gray-300 dark:border-gray-600 pl-4 italic text-gray-600 dark:text-gray-400 my-4;
   }
+
+  & :deep(ul) {
+    @apply list-disc pl-6 mb-4;
+  }
+
+  & :deep(ol) {
+    @apply list-decimal pl-6 mb-4;
+  }
+
+  & :deep(li) {
+    @apply mb-2;
+
+    p {
+      @apply mb-0;
+    }
+
+    p + p {
+      @apply mt-2;
+    }
+  }
+
+  & :deep(dd) {
+    @apply pl-4 mb-2;
+  }
+
+  & :deep(strong),
+  & :deep(b) {
+    @apply font-semibold;
+  }
+
+  & :deep(em),
+  & :deep(i) {
+    @apply italic;
+  }
+
+  & :deep(code) {
+    @apply font-mono bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300 rounded text-sm px-1 py-[0.125em];
+  }
+
+  & :deep(pre) {
+    @apply bg-gray-100 dark:bg-gray-800 rounded p-4 overflow-auto mb-4 text-sm font-mono;
+  }
+
+  & :deep(pre code) {
+    @apply bg-transparent p-0;
+  }
+
+  & :deep(hr) {
+    @apply border-t border-gray-300 dark:border-gray-600 my-6;
+  }
 }
 
 .math-view {


### PR DESCRIPTION
When rendering the HTML in exposure detail, elements need styling, and this update adds missing styles for `h1`, `ul, li`, `blockquote`, and others. 

**Before**
https://physiome.github.io/pmrapp-frontend/exposures/d19/BG_cGMP.cellml

**After**
https://akhuoa.github.io/pmrapp-frontend/exposures/d19/BG_cGMP.cellml

<br>

**Before**
https://physiome.github.io/pmrapp-frontend/exposures/cbf/BG_CaL.cellml

**After**
https://akhuoa.github.io/pmrapp-frontend/exposures/cbf/BG_CaL.cellml