### PR TITLE
Decode params in generating citation URL

### DIFF
--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -140,8 +140,9 @@ const fileBrowserPath = computed(() => {
 const citationUrl = computed(() => {
   const resolved = router.resolve({ name: route.name, params: route.params })
   const resolvedURL = new URL(resolved.href, window.location.origin)
+  const decodedHref = decodeURIComponent(resolved.href)
 
-  return resolvedURL.origin + resolved.href
+  return resolvedURL.origin + decodedHref
 })
 
 const handleFileBrowserFolderClick = (name: string) => {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -137,6 +137,9 @@ const fileBrowserPath = computed(() => {
   return typeof p === 'string' ? p : undefined
 })
 
+// Generates a citation URL from the current route, excluding query parameters and the hash.
+// It resolves the application's base path from vite.config to construct the complete URL.
+// It also maintains reactivity for navigations.
 const citationUrl = computed(() => {
   const resolved = router.resolve({ name: route.name, params: route.params })
   const resolvedURL = new URL(resolved.href, window.location.origin)

--- a/src/utils/citation.test.ts
+++ b/src/utils/citation.test.ts
@@ -1,5 +1,192 @@
 import { describe, expect, it } from 'vitest'
-import { formatCitation } from './citation'
+import {
+  formatCitation,
+  parseFullNameToAuthor,
+  formatCitationAuthor,
+  formatIndividualAuthor,
+  ensureSentence,
+  normaliseUrl,
+} from './citation'
+
+describe('parseFullNameToAuthor', () => {
+  it('parses a single name as family name', () => {
+    expect(parseFullNameToAuthor('Madonna')).toEqual({ family: 'Madonna' })
+  })
+
+  it('parses two names as given and family', () => {
+    expect(parseFullNameToAuthor('Jane Doe')).toEqual({ given: 'Jane', family: 'Doe' })
+  })
+
+  it('parses three names as given, other, and family', () => {
+    expect(parseFullNameToAuthor('John Michael Smith')).toEqual({
+      given: 'John',
+      other: 'Michael',
+      family: 'Smith',
+    })
+  })
+
+  it('parses four names as given, other (multiple), and family', () => {
+    expect(parseFullNameToAuthor('John Michael David Smith')).toEqual({
+      given: 'John',
+      other: 'Michael David',
+      family: 'Smith',
+    })
+  })
+
+  it('handles leading and trailing whitespace', () => {
+    expect(parseFullNameToAuthor('  Jane Doe  ')).toEqual({ given: 'Jane', family: 'Doe' })
+  })
+
+  it('handles multiple spaces between names', () => {
+    expect(parseFullNameToAuthor('Jane    Marie    Doe')).toEqual({
+      given: 'Jane',
+      other: 'Marie',
+      family: 'Doe',
+    })
+  })
+
+  it('returns empty family name for empty string', () => {
+    expect(parseFullNameToAuthor('')).toEqual({ family: '' })
+  })
+
+  it('returns empty family name for whitespace-only string', () => {
+    expect(parseFullNameToAuthor('   ')).toEqual({ family: '' })
+  })
+})
+
+describe('formatCitationAuthor', () => {
+  it('formats author with lastname and firstname', () => {
+    expect(formatCitationAuthor(['Doe', 'Jane'])).toBe('Jane Doe')
+  })
+
+  it('formats author with lastname, firstname, and middle initial', () => {
+    expect(formatCitationAuthor(['Doe', 'Jane', 'M'])).toBe('Jane M. Doe')
+  })
+
+  it('returns single part as is', () => {
+    expect(formatCitationAuthor(['Madonna'])).toBe('Madonna')
+  })
+
+  it('only uses first 3 elements when array has more than 3 elements', () => {
+    expect(formatCitationAuthor(['Doe', 'Jane', 'M', 'Extra'])).toBe('Jane M. Doe')
+  })
+
+  it('handles empty array', () => {
+    expect(formatCitationAuthor([])).toBe('')
+  })
+})
+
+describe('formatIndividualAuthor', () => {
+  it('formats author with family and given name', () => {
+    expect(formatIndividualAuthor({ family: 'Doe', given: 'Jane' })).toBe('Doe, J.')
+  })
+
+  it('formats author with family, given, and other name', () => {
+    expect(formatIndividualAuthor({ family: 'Smith', given: 'John', other: 'Michael' })).toBe(
+      'Smith, J. M.',
+    )
+  })
+
+  it('formats author with only family name', () => {
+    expect(formatIndividualAuthor({ family: 'Madonna' })).toBe('Madonna')
+  })
+
+  it('formats author with empty given name', () => {
+    expect(formatIndividualAuthor({ family: 'Doe', given: '' })).toBe('Doe')
+  })
+
+  it('formats author with empty other name', () => {
+    expect(formatIndividualAuthor({ family: 'Doe', given: 'Jane', other: '' })).toBe('Doe, J.')
+  })
+
+  it('handles author with all empty properties', () => {
+    expect(formatIndividualAuthor({ family: '', given: '', other: '' })).toBe('')
+  })
+})
+
+describe('ensureSentence', () => {
+  it('adds period to sentence without punctuation', () => {
+    expect(ensureSentence('This is a sentence')).toBe('This is a sentence.')
+  })
+
+  it('does not add period if sentence ends with period', () => {
+    expect(ensureSentence('This is a sentence.')).toBe('This is a sentence.')
+  })
+
+  it('does not add period if sentence ends with question mark', () => {
+    expect(ensureSentence('Is this a sentence?')).toBe('Is this a sentence?')
+  })
+
+  it('does not add period if sentence ends with exclamation mark', () => {
+    expect(ensureSentence('This is a sentence!')).toBe('This is a sentence!')
+  })
+
+  it('trims leading and trailing whitespace', () => {
+    expect(ensureSentence('  This is a sentence  ')).toBe('This is a sentence.')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(ensureSentence('')).toBe('')
+  })
+
+  it('returns empty string for whitespace-only input', () => {
+    expect(ensureSentence('   ')).toBe('')
+  })
+})
+
+describe('normaliseUrl', () => {
+  it('removes query parameters from URL', () => {
+    expect(normaliseUrl('https://example.com/article?query=1')).toBe('https://example.com/article')
+  })
+
+  it('removes hash from URL', () => {
+    expect(normaliseUrl('https://example.com/article#section')).toBe('https://example.com/article')
+  })
+
+  it('removes both query and hash from URL', () => {
+    expect(normaliseUrl('https://example.com/article?query=1#section')).toBe(
+      'https://example.com/article',
+    )
+  })
+
+  it('handles HTTP protocol', () => {
+    expect(normaliseUrl('http://example.com/article?query=1#section')).toBe(
+      'http://example.com/article',
+    )
+  })
+
+  it('returns empty string for invalid protocol', () => {
+    expect(normaliseUrl('ftp://example.com/article')).toBe('')
+  })
+
+  it('trims whitespace from URL', () => {
+    expect(normaliseUrl('  https://example.com/article  ')).toBe('https://example.com/article')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(normaliseUrl('')).toBe('')
+  })
+
+  it('returns empty string for whitespace-only input', () => {
+    expect(normaliseUrl('   ')).toBe('')
+  })
+
+  it('returns empty string for malformed URL', () => {
+    expect(normaliseUrl('not a url')).toBe('')
+  })
+
+  it('preserves path in URL', () => {
+    expect(normaliseUrl('https://example.com/path/to/article?query=1#section')).toBe(
+      'https://example.com/path/to/article',
+    )
+  })
+
+  it('preserves URL with special characters %20 for spaces', () => {
+    expect(normaliseUrl('http://localhost:5173/pmrapp-frontend/exposures/d6a/mapclient%20workflow/Argon_Viewer-previous-docs/document_whole_body.json')).toBe(
+      'http://localhost:5173/pmrapp-frontend/exposures/d6a/mapclient%20workflow/Argon_Viewer-previous-docs/document_whole_body.json',
+    )
+  })
+})
 
 describe('formatCitation', () => {
   it('formats a complete citation with authors, year, title, journal, volume, pages, publisher, and URL', () => {


### PR DESCRIPTION
Fixes #196.

After reviewing several pages for the citation update, I found that the citation URL is encoded, and it doesn't match the actual URL in the browser's address bar.

**Example** 

https://physiome.github.io/pmrapp-frontend/exposures/cbf/exposure/L-type_calcium_channel_3JBR.png

In the above page, the actual URL is `https://physiome.github.io/pmrapp-frontend/exposures/cbf/exposure/L-type_calcium_channel_3JBR.png`, and the citation URL is `https://physiome.github.io/pmrapp-frontend/exposures/cbf/exposure%2FL-type_calcium_channel_3JBR.png`, where the path **`exposure/L-type...`** is encoded as **`exposure%2FL-type...`** in the citation URL.

The fix has been applied to https://akhuoa.github.io/pmrapp-frontend/exposures/cbf/exposure/L-type_calcium_channel_3JBR.png, and it now shows the same URL in the citation as in the browser's address bar. 

Additionally, I've added unit tests for citation formatting utility functions. 
