### PR TITLE
Update page titles

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -40,6 +40,16 @@
       }
     },
     {
+      "includes": ["**/*.ts", "**/*.vue"],
+      "linter": {
+        "rules": {
+          "style": {
+            "useVueMultiWordComponentNames": "off"
+          }
+        }
+      }
+    },
+    {
       "assist": {
         "actions": {
           "source": {

--- a/src/components/atoms/ActionButton.vue
+++ b/src/components/atoms/ActionButton.vue
@@ -54,16 +54,16 @@ const disabledClasses = {
   icon: 'disabled:opacity-60 disabled:cursor-not-allowed',
 }
 
-const secondaryLightModeClasses = 'bg-gray-100 enabled:hover:bg-gray-100'
-const secondaryDarkModeClasses = 'dark:bg-gray-600 enabled:dark:hover:bg-gray-500'
+const secondaryLightModeClasses = 'bg-gray-100 hover:bg-gray-100'
+const secondaryDarkModeClasses = 'dark:bg-gray-600 dark:hover:bg-gray-500'
 
 const transitionClasses = 'transition duration-200 ease-linear'
 
 const variantClasses = {
-  primary: `px-3 py-1 rounded border border-primary bg-primary text-white enabled:hover:opacity-90 ${transitionClasses}`,
-  secondary: `px-3 py-1 rounded border border-primary text-link enabled:hover:text-link-hover ${transitionClasses} ${secondaryLightModeClasses} ${secondaryDarkModeClasses}`,
-  link: `text-primary enabled:hover:text-primary-hover ${transitionClasses}`,
-  icon: `p-2 rounded text-gray-700 dark:text-gray-300 enabled:hover:bg-gray-100 enabled:dark:hover:bg-gray-700 ${transitionClasses}`,
+  primary: `px-3 py-1 rounded border border-primary bg-primary text-white hover:opacity-90 ${transitionClasses}`,
+  secondary: `px-3 py-1 rounded border border-primary text-link hover:text-link-hover ${transitionClasses} ${secondaryLightModeClasses} ${secondaryDarkModeClasses}`,
+  link: `text-primary hover:text-primary-hover ${transitionClasses}`,
+  icon: `p-2 rounded text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 ${transitionClasses}`,
 }
 
 const sizeClasses = {

--- a/src/components/atoms/BackToTop.vue
+++ b/src/components/atoms/BackToTop.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from 'vue'
 import ArrowUpIcon from '@/components/icons/ArrowUpIcon.vue'

--- a/src/components/atoms/Chip.vue
+++ b/src/components/atoms/Chip.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { ref } from 'vue'
 import CloseButton from '@/components/atoms/CloseButton.vue'
 
 interface Props {

--- a/src/components/atoms/CodeBlock.vue
+++ b/src/components/atoms/CodeBlock.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 import Prism from 'prismjs'
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'

--- a/src/components/molecules/PageHeader.vue
+++ b/src/components/molecules/PageHeader.vue
@@ -1,21 +1,23 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 
-const props = defineProps<{
+interface Props {
   title: string
   description?: string
   centered?: boolean
   titleSize?: 'small' | 'medium' | 'large'
-}>()
+}
 
-const titleFontSize = computed(() => {
+const props = withDefaults(defineProps<Props>(), {
+  titleSize: 'large',
+})
+
+const titleFontSize = computed((): string => {
   switch (props.titleSize) {
     case 'small':
       return 'text-2xl'
     case 'medium':
       return 'text-3xl'
-    case 'large':
-      return 'text-4xl'
     default:
       return 'text-4xl'
   }

--- a/src/components/molecules/PageHeader.vue
+++ b/src/components/molecules/PageHeader.vue
@@ -3,12 +3,15 @@ defineProps<{
   title: string
   description?: string
   centered?: boolean
+  titleSize?: 'small' | 'medium' | 'large'
 }>()
 </script>
 
 <template>
   <div :class="{ 'text-center': centered }">
-    <h1 class="text-4xl font-bold mb-6">{{ title }}</h1>
+    <h1 :class="`text-${titleSize === 'small' ? '2xl' : titleSize === 'medium' ? '3xl' : '4xl'} font-bold mb-6`">
+      {{ title }}
+    </h1>
     <p v-if="description" class="text-lg mb-8">
       {{ description }}
     </p>

--- a/src/components/molecules/PageHeader.vue
+++ b/src/components/molecules/PageHeader.vue
@@ -1,15 +1,30 @@
 <script setup lang="ts">
-defineProps<{
+import { computed } from 'vue'
+
+const props = defineProps<{
   title: string
   description?: string
   centered?: boolean
   titleSize?: 'small' | 'medium' | 'large'
 }>()
+
+const titleFontSize = computed(() => {
+  switch (props.titleSize) {
+    case 'small':
+      return 'text-2xl'
+    case 'medium':
+      return 'text-3xl'
+    case 'large':
+      return 'text-4xl'
+    default:
+      return 'text-4xl'
+  }
+})
 </script>
 
 <template>
   <div :class="{ 'text-center': centered }">
-    <h1 :class="`text-${titleSize === 'small' ? '2xl' : titleSize === 'medium' ? '3xl' : '4xl'} font-bold mb-6`">
+    <h1 :class="`${titleFontSize} font-bold mb-6`">
       {{ title }}
     </h1>
     <p v-if="description" class="text-lg mb-8">

--- a/src/components/organisms/ExposureDetail.test.ts
+++ b/src/components/organisms/ExposureDetail.test.ts
@@ -3,10 +3,10 @@ import { createPinia, setActivePinia } from 'pinia'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick } from 'vue'
 import ExposureDetail from '@/components/organisms/ExposureDetail.vue'
+import { TITLE } from '@/constants/global'
 import { mockExposureInfo, mockGeneratedCode, mockMetadata } from '@/mocks/exposureInfo'
 import { useExposureStore } from '@/stores/exposure'
 import { useSearchStore } from '@/stores/search'
-import { TITLE } from '@/constants/global'
 
 // Mock Vue Router.
 vi.mock('vue-router', () => ({

--- a/src/components/organisms/ExposureDetail.test.ts
+++ b/src/components/organisms/ExposureDetail.test.ts
@@ -188,7 +188,7 @@ describe('ExposureDetail', () => {
 
     const title = wrapper.find('h1')
     expect(title.exists()).toBe(true)
-    expect(title.text()).toBe(`${titleText} – ${TITLE}`)
+    expect(title.text()).toBe(`${titleText}`)
   })
 
   it('renders html-view with content', async () => {

--- a/src/components/organisms/ExposureDetail.test.ts
+++ b/src/components/organisms/ExposureDetail.test.ts
@@ -190,6 +190,26 @@ describe('ExposureDetail', () => {
     expect(title.text()).toBe(titleText)
   })
 
+  it('sets document.title to pageTitle on mount', async () => {
+    const { document: doc } = window
+    doc.title = ''
+
+    await mountComponent()
+
+    expect(doc.title).toBe('Baylor, Hollingworth, Chandler, 2002')
+  })
+
+  it('sets document.title to the view name when a view prop is provided', async () => {
+    const { document: doc } = window
+    doc.title = ''
+
+    await mountComponent({
+      props: { view: 'cellml_codegen' },
+    })
+
+    expect(doc.title).toBe('Generate code')
+  })
+
   it('renders html-view with content', async () => {
     const wrapper = await mountComponent()
 

--- a/src/components/organisms/ExposureDetail.test.ts
+++ b/src/components/organisms/ExposureDetail.test.ts
@@ -190,26 +190,6 @@ describe('ExposureDetail', () => {
     expect(title.text()).toBe(titleText)
   })
 
-  it('sets document.title to pageTitle on mount', async () => {
-    const { document: doc } = window
-    doc.title = ''
-
-    await mountComponent()
-
-    expect(doc.title).toBe('Baylor, Hollingworth, Chandler, 2002')
-  })
-
-  it('sets document.title to the view name when a view prop is provided', async () => {
-    const { document: doc } = window
-    doc.title = ''
-
-    await mountComponent({
-      props: { view: 'cellml_codegen' },
-    })
-
-    expect(doc.title).toBe('Generate code')
-  })
-
   it('renders html-view with content', async () => {
     const wrapper = await mountComponent()
 

--- a/src/components/organisms/ExposureDetail.test.ts
+++ b/src/components/organisms/ExposureDetail.test.ts
@@ -6,6 +6,7 @@ import ExposureDetail from '@/components/organisms/ExposureDetail.vue'
 import { mockExposureInfo, mockGeneratedCode, mockMetadata } from '@/mocks/exposureInfo'
 import { useExposureStore } from '@/stores/exposure'
 import { useSearchStore } from '@/stores/search'
+import { TITLE } from '@/constants/global'
 
 // Mock Vue Router.
 vi.mock('vue-router', () => ({
@@ -187,7 +188,7 @@ describe('ExposureDetail', () => {
 
     const title = wrapper.find('h1')
     expect(title.exists()).toBe(true)
-    expect(title.text()).toBe(titleText)
+    expect(title.text()).toBe(`${titleText} – ${TITLE}`)
   })
 
   it('renders html-view with content', async () => {
@@ -364,7 +365,7 @@ describe('ExposureDetail', () => {
     expect(citationBlock?.textContent).toContain(
       'Comparison of Simulated and Measured Calcium Sparks in Intact Skeletal Muscle Fibers of the Frog (Reaction A)',
     )
-    expect(citationBlock?.textContent).toContain('Physiome Model Repository')
+    expect(citationBlock?.textContent).toContain(TITLE)
   })
 
   it('renders "Keywords" section with correct content', async () => {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -188,6 +188,14 @@ watch(
   { immediate: true },
 )
 
+watch(
+  fileBrowserPath,
+  (newPath) => {
+    document.title = pageTitle.value
+  },
+  { immediate: true },
+)
+
 const openCORFiles = computed(() => {
   if (!exposureInfo.value) return []
 

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -165,6 +165,16 @@ const pageTitle = computed(() => {
   return exposureInfo.value.exposure.description || `Exposure ${exposureInfo.value.exposure.id}`
 })
 
+watch(
+  pageTitle,
+  (newTitle) => {
+    if (newTitle) {
+      document.title = newTitle
+    }
+  },
+  { immediate: true },
+)
+
 const openCORFiles = computed(() => {
   if (!exposureInfo.value) return []
 

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -178,16 +178,6 @@ const pageTitle = computed(() => {
   return exposureInfo.value?.exposure.description || props.alias
 })
 
-watch(pageTitle, (newTitle) => {
-  if (newTitle) {
-    document.title = newTitle
-  }
-})
-
-watch(fileBrowserPath, () => {
-  document.title = pageTitle.value
-})
-
 const openCORFiles = computed(() => {
   if (!exposureInfo.value) return []
 

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -177,7 +177,10 @@ const pageTitle = computed(() => {
     }
   }
 
-  return generateExposureTitle(exposureInfo.value?.exposure.description, exposureInfo.value?.exposure.id)
+  return generateExposureTitle(
+    exposureInfo.value?.exposure.description,
+    exposureInfo.value?.exposure.id,
+  )
 })
 
 const openCORFiles = computed(() => {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -178,14 +178,11 @@ const pageTitle = computed(() => {
   return exposureInfo.value?.exposure.description || props.alias
 })
 
-watch(
-  pageTitle,
-  (newTitle) => {
-    if (newTitle) {
-      document.title = newTitle
-    }
-  },
-)
+watch(pageTitle, (newTitle) => {
+  if (newTitle) {
+    document.title = newTitle
+  }
+})
 
 watch(fileBrowserPath, () => {
   document.title = pageTitle.value

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 import { computed, nextTick, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -34,6 +34,8 @@ import { formatYear } from '@/utils/format'
 import { formatLicenseUrl } from '@/utils/license'
 import { formatMathMLTable, initMathPolyfills, transformMathString } from '@/utils/mathTransformer'
 import { buildSearchQuery, isValidTerm } from '@/utils/search'
+import { generateExposureTitle } from '@/utils/exposure'
+import { TITLE } from '@/constants/global'
 
 type ExposureFileEntry = ExposureInfo['files'][number]
 
@@ -175,7 +177,7 @@ const pageTitle = computed(() => {
     }
   }
 
-  return exposureInfo.value?.exposure.description || props.alias
+  return generateExposureTitle(exposureInfo.value?.exposure.description, exposureInfo.value?.exposure.id)
 })
 
 const openCORFiles = computed(() => {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -178,6 +178,7 @@ const pageTitle = computed(() => {
   return generateExposureTitle(
     exposureInfo.value?.exposure.description,
     exposureInfo.value?.exposure.id,
+    false,
   )
 })
 

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -190,7 +190,7 @@ watch(
 
 watch(
   fileBrowserPath,
-  (newPath) => {
+  () => {
     document.title = pageTitle.value
   },
   { immediate: true },

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -18,6 +18,7 @@ import MathTransformOptions from '@/components/molecules/MathTransformOptions.vu
 import PageHeader from '@/components/molecules/PageHeader.vue'
 import WorkspaceFileBrowser from '@/components/molecules/WorkspaceFileBrowser.vue'
 import { useBackNavigation } from '@/composables/useBackNavigation'
+import { TITLE } from '@/constants/global'
 import { getMathFormatOptionsStorageService } from '@/services'
 import { downloadCOMBINEArchive, downloadWorkspaceArchive } from '@/services/downloadUrlService'
 import { useExposureStore } from '@/stores/exposure'
@@ -27,14 +28,12 @@ import type { ExposureInfo, Metadata, ViewEntry } from '@/types/exposure'
 import type { MathMLFormatOptions } from '@/types/mathml'
 import { formatCitation, formatCitationAuthor, parseFullNameToAuthor } from '@/utils/citation'
 import { downloadFileFromContent } from '@/utils/download'
-import { getExposureIdFromResourcePath } from '@/utils/exposure'
+import { generateExposureTitle, getExposureIdFromResourcePath } from '@/utils/exposure'
 import { getFileExtension, isOpenCORFile } from '@/utils/file'
 import { formatYear } from '@/utils/format'
 import { formatLicenseUrl } from '@/utils/license'
 import { formatMathMLTable, initMathPolyfills, transformMathString } from '@/utils/mathTransformer'
 import { buildSearchQuery, isValidTerm } from '@/utils/search'
-import { generateExposureTitle } from '@/utils/exposure'
-import { TITLE } from '@/constants/global'
 
 type ExposureFileEntry = ExposureInfo['files'][number]
 

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -188,12 +188,9 @@ watch(
   { immediate: true },
 )
 
-watch(
-  fileBrowserPath,
-  () => {
-    document.title = pageTitle.value
-  },
-)
+watch(fileBrowserPath, () => {
+  document.title = pageTitle.value
+})
 
 const openCORFiles = computed(() => {
   if (!exposureInfo.value) return []

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -193,7 +193,6 @@ watch(
   () => {
     document.title = pageTitle.value
   },
-  { immediate: true },
 )
 
 const openCORFiles = computed(() => {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -174,8 +174,8 @@ const pageTitle = computed(() => {
       return `${viewEntry.name}`
     }
   }
-  if (!exposureInfo.value) return ''
-  return exposureInfo.value.exposure.description || `Exposure ${exposureInfo.value.exposure.id}`
+
+  return exposureInfo.value?.exposure.description || props.alias
 })
 
 watch(

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -185,7 +185,6 @@ watch(
       document.title = newTitle
     }
   },
-  { immediate: true },
 )
 
 watch(fileBrowserPath, () => {

--- a/src/components/organisms/ExposureDetail.vue
+++ b/src/components/organisms/ExposureDetail.vue
@@ -424,7 +424,7 @@ const modelCitation = computed(() => {
     authors: citationAuthors.value,
     issued: createdYear.value,
     url: citationUrl.value,
-    publisher: 'Physiome Model Repository',
+    publisher: TITLE,
   }
 })
 

--- a/src/components/organisms/ExposureFileDetail.vue
+++ b/src/components/organisms/ExposureFileDetail.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import BackButton from '@/components/atoms/BackButton.vue'

--- a/src/components/organisms/Exposures.vue
+++ b/src/components/organisms/Exposures.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import List from '@/components/molecules/List.vue'

--- a/src/components/organisms/Footer.vue
+++ b/src/components/organisms/Footer.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 import GitHubIcon from '@/components/icons/GitHubIcon.vue'
 

--- a/src/components/organisms/Header.vue
+++ b/src/components/organisms/Header.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 import { computed, ref } from 'vue'
 import { useRoute } from 'vue-router'

--- a/src/components/organisms/Home.vue
+++ b/src/components/organisms/Home.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 import KeywordBrowser from '@/components/molecules/KeywordBrowser.vue'
 import NavigationCard from '@/components/molecules/NavigationCard.vue'

--- a/src/components/organisms/Login.vue
+++ b/src/components/organisms/Login.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'

--- a/src/components/organisms/Search.vue
+++ b/src/components/organisms/Search.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'

--- a/src/components/organisms/WorkspaceDetail.vue
+++ b/src/components/organisms/WorkspaceDetail.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'

--- a/src/components/organisms/WorkspaceDetail.vue
+++ b/src/components/organisms/WorkspaceDetail.vue
@@ -89,6 +89,20 @@ const handleDownloadWorkspaceArchive = async (format: 'zip' | 'tgz') => {
   }
 }
 
+const pageTitle = computed(() => {
+  return workspaceInfo.value?.workspace.description || props.alias
+})
+
+watch(
+  pageTitle,
+  (newTitle) => {
+    if (newTitle) {
+      document.title = newTitle
+    }
+  },
+  { immediate: true },
+)
+
 const loadWorkspaceInfo = async () => {
   isLoading.value = true
   error.value = null
@@ -151,7 +165,7 @@ watch(() => [props.alias, props.commitId, props.path], loadWorkspaceInfo)
 
   <div v-else-if="workspaceInfo">
     <PageHeader
-      :title="workspaceInfo.workspace.description || alias"
+      :title="pageTitle"
     />
 
     <div class="mb-6 space-y-4">

--- a/src/components/organisms/WorkspaceDetail.vue
+++ b/src/components/organisms/WorkspaceDetail.vue
@@ -105,7 +105,6 @@ watch(
       document.title = newTitle
     }
   },
-  { immediate: true },
 )
 
 const loadWorkspaceInfo = async () => {

--- a/src/components/organisms/WorkspaceDetail.vue
+++ b/src/components/organisms/WorkspaceDetail.vue
@@ -93,6 +93,7 @@ const pageTitle = computed(() => {
   return generateWorkspaceTitle(
     workspaceInfo.value?.workspace.description,
     workspaceInfo.value?.workspace.id,
+    false,
   )
 })
 

--- a/src/components/organisms/WorkspaceDetail.vue
+++ b/src/components/organisms/WorkspaceDetail.vue
@@ -98,14 +98,11 @@ const pageTitle = computed(() => {
   return workspaceInfo.value?.workspace.description || props.alias
 })
 
-watch(
-  pageTitle,
-  (newTitle) => {
-    if (newTitle) {
-      document.title = newTitle
-    }
-  },
-)
+watch(pageTitle, (newTitle) => {
+  if (newTitle) {
+    document.title = newTitle
+  }
+})
 
 const loadWorkspaceInfo = async () => {
   isLoading.value = true

--- a/src/components/organisms/WorkspaceDetail.vue
+++ b/src/components/organisms/WorkspaceDetail.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import ActionButton from '@/components/atoms/ActionButton.vue'
 import BackButton from '@/components/atoms/BackButton.vue'
@@ -30,11 +30,6 @@ const isLoading = ref(true)
 const isDownloadingWorkspaceZip = ref(false)
 const isDownloadingWorkspaceTgz = ref(false)
 const requestCounter = ref(0)
-const isUnmounted = ref(false)
-
-onBeforeUnmount(() => {
-  isUnmounted.value = true
-})
 
 const backPath = computed(() => {
   if (!props.path) {
@@ -98,12 +93,6 @@ const pageTitle = computed(() => {
   return workspaceInfo.value?.workspace.description || props.alias
 })
 
-watch(pageTitle, (newTitle) => {
-  if (newTitle) {
-    document.title = newTitle
-  }
-})
-
 const loadWorkspaceInfo = async () => {
   isLoading.value = true
   error.value = null
@@ -118,9 +107,6 @@ const loadWorkspaceInfo = async () => {
 
     if (currentRequest === requestCounter.value) {
       workspaceInfo.value = workspaceData
-      if (!isUnmounted.value) {
-        document.title = workspaceData.workspace.description || alias
-      }
     }
   } catch (err) {
     if (currentRequest === requestCounter.value) {

--- a/src/components/organisms/WorkspaceDetail.vue
+++ b/src/components/organisms/WorkspaceDetail.vue
@@ -91,7 +91,10 @@ const handleDownloadWorkspaceArchive = async (format: 'zip' | 'tgz') => {
 }
 
 const pageTitle = computed(() => {
-  return generateWorkspaceTitle(workspaceInfo.value?.workspace.description, workspaceInfo.value?.workspace.id)
+  return generateWorkspaceTitle(
+    workspaceInfo.value?.workspace.description,
+    workspaceInfo.value?.workspace.id,
+  )
 })
 
 const loadWorkspaceInfo = async () => {

--- a/src/components/organisms/WorkspaceDetail.vue
+++ b/src/components/organisms/WorkspaceDetail.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import ActionButton from '@/components/atoms/ActionButton.vue'
 import BackButton from '@/components/atoms/BackButton.vue'
@@ -30,6 +30,11 @@ const isLoading = ref(true)
 const isDownloadingWorkspaceZip = ref(false)
 const isDownloadingWorkspaceTgz = ref(false)
 const requestCounter = ref(0)
+const isUnmounted = ref(false)
+
+onBeforeUnmount(() => {
+  isUnmounted.value = true
+})
 
 const backPath = computed(() => {
   if (!props.path) {
@@ -117,7 +122,9 @@ const loadWorkspaceInfo = async () => {
 
     if (currentRequest === requestCounter.value) {
       workspaceInfo.value = workspaceData
-      document.title = workspaceData.workspace.description || alias
+      if (!isUnmounted.value) {
+        document.title = workspaceData.workspace.description || alias
+      }
     }
   } catch (err) {
     if (currentRequest === requestCounter.value) {

--- a/src/components/organisms/WorkspaceDetail.vue
+++ b/src/components/organisms/WorkspaceDetail.vue
@@ -93,7 +93,6 @@ const pageTitle = computed(() => {
   return generateWorkspaceTitle(
     workspaceInfo.value?.workspace.description,
     workspaceInfo.value?.workspace.id,
-    false,
   )
 })
 

--- a/src/components/organisms/WorkspaceDetail.vue
+++ b/src/components/organisms/WorkspaceDetail.vue
@@ -15,6 +15,7 @@ import { downloadWorkspaceArchive } from '@/services/downloadUrlService'
 import { useWorkspaceStore } from '@/stores/workspace'
 import type { ErrorInfo } from '@/types/error'
 import type { WorkspaceInfo } from '@/types/workspace'
+import { generateWorkspaceTitle } from '@/utils/workspace'
 
 const props = defineProps<{
   alias: string
@@ -90,7 +91,7 @@ const handleDownloadWorkspaceArchive = async (format: 'zip' | 'tgz') => {
 }
 
 const pageTitle = computed(() => {
-  return workspaceInfo.value?.workspace.description || props.alias
+  return generateWorkspaceTitle(workspaceInfo.value?.workspace.description, workspaceInfo.value?.workspace.id)
 })
 
 const loadWorkspaceInfo = async () => {

--- a/src/components/organisms/WorkspaceDetail.vue
+++ b/src/components/organisms/WorkspaceDetail.vue
@@ -117,6 +117,7 @@ const loadWorkspaceInfo = async () => {
 
     if (currentRequest === requestCounter.value) {
       workspaceInfo.value = workspaceData
+      document.title = workspaceData.workspace.description || alias
     }
   } catch (err) {
     if (currentRequest === requestCounter.value) {

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import BackButton from '@/components/atoms/BackButton.vue'
 import CodeBlock from '@/components/atoms/CodeBlock.vue'
 import CopyButton from '@/components/atoms/CopyButton.vue'
@@ -105,6 +105,14 @@ const imageDataUrl = computed(() => {
 
 // Fast guard: avoid rendering very large payloads in the browser preview.
 const isTooLargeForPreview = computed(() => fileSizeBytes.value > MAX_PREVIEW_FILE_SIZE_BYTES)
+
+watch(
+  () => props.path,
+  (newPath) => {
+    document.title = newPath
+  },
+  { immediate: true },
+)
 
 const downloadFile = () => {
   downloadFileFromBlob(fileBlob.value, filename.value)

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -74,9 +74,7 @@ const isSvg = computed(() => isSvgFile(props.path))
 const isMarkdown = computed(() => isMarkdownFile(props.path))
 const isCode = computed(() => isCodeFile(props.path))
 const isOpenCOR = computed(() => isOpenCORFile(props.path))
-const canShowOpenCORButton = computed(
-  () => isOpenCOR.value && !!openCORFileURL.value,
-)
+const canShowOpenCORButton = computed(() => isOpenCOR.value && !!openCORFileURL.value)
 
 const openCORFileURL = computed(() => {
   const url = workspaceInfo.value?.workspace.url

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -144,9 +144,7 @@ const loadWorkspaceURLForOpenCOR = async () => {
 }
 
 const pageTitle = computed(() => {
-  const title =
-    workspaceInfo.value?.workspace.description ||
-    workspaceInfo.value?.workspace.id
+  const title = workspaceInfo.value?.workspace.description || workspaceInfo.value?.workspace.id
   const truncatedCommitId = workspaceInfo.value?.commit.commit_id.substring(0, 12)
   const pathsWithSpace = props.path.split('/').join(' / ')
 

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import ActionButton from '@/components/atoms/ActionButton.vue'
 import BackButton from '@/components/atoms/BackButton.vue'
 import CodeBlock from '@/components/atoms/CodeBlock.vue'
 import CopyButton from '@/components/atoms/CopyButton.vue'
@@ -25,7 +26,6 @@ import {
   isSvgFile,
 } from '@/utils/file'
 import { renderMarkdown } from '@/utils/markdown'
-import ActionButton from '@/components/atoms/ActionButton.vue'
 import { generateWorkspaceTitle } from '@/utils/workspace'
 
 // Files with size above this threshold are not rendered in the preview to prevent browser freeze.

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import BackButton from '@/components/atoms/BackButton.vue'

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -40,10 +40,8 @@ const fileContent = ref<string>('')
 const fileBlob = ref<Blob>(new Blob())
 const fileBlobUrl = ref<string>('')
 const fileSizeBytes = ref(0)
-const workspaceURL = ref<string>('')
 const workspaceInfo = ref<WorkspaceInfo | null>(null)
 const workspaceInfoLoading = ref(true)
-const isOpenCORURLLoading = ref(false)
 const error = ref<string | null>(null)
 const isLoading = ref(true)
 const showCode = ref(false)
@@ -76,13 +74,14 @@ const isMarkdown = computed(() => isMarkdownFile(props.path))
 const isCode = computed(() => isCodeFile(props.path))
 const isOpenCOR = computed(() => isOpenCORFile(props.path))
 const canShowOpenCORButton = computed(
-  () => isOpenCOR.value && !isOpenCORURLLoading.value && !!openCORFileURL.value,
+  () => isOpenCOR.value && !!openCORFileURL.value,
 )
 
 const openCORFileURL = computed(() => {
-  if (!workspaceURL.value) return ''
+  const url = workspaceInfo.value?.workspace.url
+  if (!url) return ''
 
-  const rawFileURL = `${workspaceURL.value}rawfile/${props.commitId}/${props.path}`
+  const rawFileURL = `${url}rawfile/${props.commitId}/${props.path}`
   const opencorLink = `opencor://openFile/${rawFileURL}`
   return `//opencor.ws/app/?${opencorLink}`
 })
@@ -130,19 +129,6 @@ const loadWorkspaceInfo = async () => {
   }
 }
 
-const loadWorkspaceURLForOpenCOR = async () => {
-  if (!isOpenCOR.value || !workspaceInfo.value) return
-
-  isOpenCORURLLoading.value = true
-  try {
-    workspaceURL.value = workspaceInfo.value.workspace.url
-  } catch (workspaceErr) {
-    console.error('Error loading workspace URL for OpenCOR link:', workspaceErr)
-  } finally {
-    isOpenCORURLLoading.value = false
-  }
-}
-
 const pageTitle = computed(() => {
   const title = workspaceInfo.value?.workspace.description || workspaceInfo.value?.workspace.id
   const truncatedCommitId = workspaceInfo.value?.commit.commit_id.substring(0, 12)
@@ -153,9 +139,6 @@ const pageTitle = computed(() => {
 
 onMounted(async () => {
   void loadWorkspaceInfo()
-
-  // OpenCOR link data loads separately so file preview is not blocked.
-  void loadWorkspaceURLForOpenCOR()
 
   try {
     const blob = await getWorkspaceService().getRawFileBlob(props.alias, props.commitId, props.path)

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import BackButton from '@/components/atoms/BackButton.vue'
 import CodeBlock from '@/components/atoms/CodeBlock.vue'
 import CopyButton from '@/components/atoms/CopyButton.vue'
@@ -109,7 +109,9 @@ const isTooLargeForPreview = computed(() => fileSizeBytes.value > MAX_PREVIEW_FI
 watch(
   () => props.path,
   (newPath) => {
-    document.title = newPath
+    nextTick(() => {
+      document.title = newPath
+    })
   },
   { immediate: true },
 )

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -14,6 +14,7 @@ import PageHeader from '@/components/molecules/PageHeader.vue'
 import { useBackNavigation } from '@/composables/useBackNavigation'
 import { getWorkspaceService } from '@/services'
 import { useWorkspaceStore } from '@/stores/workspace'
+import type { WorkspaceInfo } from '@/types/workspace'
 import { downloadFileFromBlob } from '@/utils/download'
 import {
   isCodeFile,
@@ -25,7 +26,6 @@ import {
 } from '@/utils/file'
 import { renderMarkdown } from '@/utils/markdown'
 import ActionButton from '../atoms/ActionButton.vue'
-import type { WorkspaceInfo } from '@/types/workspace'
 
 // Files with size above this threshold are not rendered in the preview to prevent browser freeze.
 const MAX_PREVIEW_FILE_SIZE_BYTES = 500 * 1024 // ~500 KB

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -25,7 +25,8 @@ import {
   isSvgFile,
 } from '@/utils/file'
 import { renderMarkdown } from '@/utils/markdown'
-import ActionButton from '../atoms/ActionButton.vue'
+import ActionButton from '@/components/atoms/ActionButton.vue'
+import { generateWorkspaceTitle } from '@/utils/workspace'
 
 // Files with size above this threshold are not rendered in the preview to prevent browser freeze.
 const MAX_PREVIEW_FILE_SIZE_BYTES = 500 * 1024 // ~500 KB
@@ -130,8 +131,12 @@ const loadWorkspaceInfo = async () => {
 }
 
 const pageTitle = computed(() => {
-  const title = workspaceInfo.value?.workspace.description || workspaceInfo.value?.workspace.id
-  const truncatedCommitId = workspaceInfo.value?.commit.commit_id.substring(0, 12)
+  const title = generateWorkspaceTitle(
+    workspaceInfo.value?.workspace.description,
+    workspaceInfo.value?.workspace.id,
+    false,
+  )
+  const truncatedCommitId = props.commitId.substring(0, 12)
   const pathsWithSpace = props.path.split('/').join(' / ')
 
   return `${title} @ ${truncatedCommitId} / ${pathsWithSpace}`

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -132,12 +132,12 @@ const pageTitle = computed(() => {
   const title = generateWorkspaceTitle(
     workspaceInfo.value?.workspace.description,
     workspaceInfo.value?.workspace.id,
+    props.commitId,
+    props.path,
     false,
   )
-  const truncatedCommitId = props.commitId.substring(0, 12)
-  const pathsWithSpace = props.path.split('/').join(' / ')
 
-  return `${title} @ ${truncatedCommitId} / ${pathsWithSpace}`
+  return title
 })
 
 onMounted(async () => {

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import BackButton from '@/components/atoms/BackButton.vue'
 import CodeBlock from '@/components/atoms/CodeBlock.vue'
 import CopyButton from '@/components/atoms/CopyButton.vue'
@@ -105,14 +105,6 @@ const imageDataUrl = computed(() => {
 
 // Fast guard: avoid rendering very large payloads in the browser preview.
 const isTooLargeForPreview = computed(() => fileSizeBytes.value > MAX_PREVIEW_FILE_SIZE_BYTES)
-
-watch(
-  () => props.path,
-  (newPath) => {
-    document.title = newPath
-  },
-  { immediate: true },
-)
 
 const downloadFile = () => {
   downloadFileFromBlob(fileBlob.value, filename.value)

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -25,6 +25,7 @@ import {
 } from '@/utils/file'
 import { renderMarkdown } from '@/utils/markdown'
 import ActionButton from '../atoms/ActionButton.vue'
+import type { WorkspaceInfo } from '@/types/workspace'
 
 // Files with size above this threshold are not rendered in the preview to prevent browser freeze.
 const MAX_PREVIEW_FILE_SIZE_BYTES = 500 * 1024 // ~500 KB
@@ -40,6 +41,8 @@ const fileBlob = ref<Blob>(new Blob())
 const fileBlobUrl = ref<string>('')
 const fileSizeBytes = ref(0)
 const workspaceURL = ref<string>('')
+const workspaceInfo = ref<WorkspaceInfo | null>(null)
+const workspaceInfoLoading = ref(true)
 const isOpenCORURLLoading = ref(false)
 const error = ref<string | null>(null)
 const isLoading = ref(true)
@@ -117,13 +120,22 @@ const toggleCodeWrap = () => {
   codeBlockRef.value?.toggleWrap()
 }
 
+const loadWorkspaceInfo = async () => {
+  try {
+    workspaceInfo.value = await workspaceStore.getWorkspaceInfo(props.alias, props.commitId, '')
+  } catch (workspaceErr) {
+    console.error('Error loading workspace info:', workspaceErr)
+  } finally {
+    workspaceInfoLoading.value = false
+  }
+}
+
 const loadWorkspaceURLForOpenCOR = async () => {
-  if (!isOpenCOR.value) return
+  if (!isOpenCOR.value || !workspaceInfo.value) return
 
   isOpenCORURLLoading.value = true
   try {
-    const workspaceInfo = await workspaceStore.getWorkspaceInfo(props.alias, props.commitId, '')
-    workspaceURL.value = workspaceInfo.workspace.url
+    workspaceURL.value = workspaceInfo.value.workspace.url
   } catch (workspaceErr) {
     console.error('Error loading workspace URL for OpenCOR link:', workspaceErr)
   } finally {
@@ -131,7 +143,19 @@ const loadWorkspaceURLForOpenCOR = async () => {
   }
 }
 
+const pageTitle = computed(() => {
+  const title =
+    workspaceInfo.value?.workspace.description ||
+    workspaceInfo.value?.workspace.id
+  const truncatedCommitId = workspaceInfo.value?.commit.commit_id.substring(0, 12)
+  const pathsWithSpace = props.path.split('/').join(' / ')
+
+  return `${title} @ ${truncatedCommitId} / ${pathsWithSpace}`
+})
+
 onMounted(async () => {
+  void loadWorkspaceInfo()
+
   // OpenCOR link data loads separately so file preview is not blocked.
   void loadWorkspaceURLForOpenCOR()
 
@@ -177,6 +201,8 @@ onBeforeUnmount(() => {
     :on-click="goBack"
   />
 
+  <PageHeader v-if="!workspaceInfoLoading" :title="pageTitle" titleSize="small" />
+
   <ErrorBlock
     v-if="error"
     title="Error loading file"
@@ -186,10 +212,11 @@ onBeforeUnmount(() => {
   <LoadingBox v-else-if="isLoading" message="Loading file..." />
 
   <div v-else>
-    <PageHeader :title="path" />
-
     <div class="box p-0! overflow-hidden">
-      <div class="flex items-center justify-end px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+      <div class="flex items-center justify-between px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+        <div>
+          {{ filename }}
+        </div>
         <div class="flex items-center gap-2">
           <button
             v-if="isSvg || isMarkdown"

--- a/src/components/organisms/WorkspaceFileDetail.vue
+++ b/src/components/organisms/WorkspaceFileDetail.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import BackButton from '@/components/atoms/BackButton.vue'
 import CodeBlock from '@/components/atoms/CodeBlock.vue'
 import CopyButton from '@/components/atoms/CopyButton.vue'
@@ -109,9 +109,7 @@ const isTooLargeForPreview = computed(() => fileSizeBytes.value > MAX_PREVIEW_FI
 watch(
   () => props.path,
   (newPath) => {
-    nextTick(() => {
-      document.title = newPath
-    })
+    document.title = newPath
   },
   { immediate: true },
 )

--- a/src/components/organisms/Workspaces.vue
+++ b/src/components/organisms/Workspaces.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
 import { onMounted } from 'vue'
 import List from '@/components/molecules/List.vue'

--- a/src/constants/global.ts
+++ b/src/constants/global.ts
@@ -1,0 +1,5 @@
+/**
+ * Global constants.
+ */
+
+export const TITLE = 'Physiome Model Repository'

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -198,7 +198,7 @@ const router = createRouter({
 router.beforeResolve(async (to) => {
   const resolvedTitle = await resolveRouteTitle(to)
   if (resolvedTitle) {
-    to.meta.title = resolvedTitle
+    to.meta.title = resolvedTitle.includes(title) ? resolvedTitle : `${resolvedTitle} – ${title}`
   }
 })
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -54,7 +54,11 @@ const resolveExposureTitle = async (to: RouteLocationNormalized) => {
   try {
     const exposureInfo = await useExposureStore().getExposureInfo(alias)
 
-    return generateExposureTitle(exposureInfo?.exposure?.description, exposureInfo?.exposure?.id)
+    return generateExposureTitle(
+      exposureInfo?.exposure?.description,
+      exposureInfo?.exposure?.id,
+      true,
+    )
   } catch (error) {
     console.error(`Error fetching exposure info for alias ${alias}:`, error)
   }
@@ -76,6 +80,7 @@ const resolveWorkspaceTitle = async (to: RouteLocationNormalized) => {
     return generateWorkspaceTitle(
       workspaceInfo?.workspace?.description,
       workspaceInfo?.workspace?.id,
+      true,
     )
   } catch (error) {
     console.error(`Error fetching workspace info for alias ${alias}:`, error)

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory, type NavigationGuard } from 'vue-router'
+import { createRouter, createWebHistory, type RouteLocationNormalized } from 'vue-router'
 import { useExposureStore } from '@/stores/exposure'
 import { useWorkspaceStore } from '@/stores/workspace'
 import ExposureDetailView from '@/views/ExposureDetailView.vue'
@@ -43,30 +43,23 @@ const createPluralRouteAliases = (pluralBase: string, aliasBases: string[], suff
   ...createAliases(aliasBases, ...suffixes),
 ]
 
-const exposureBeforeEnter: NavigationGuard = async (to, _from, next) => {
+const resolveExposureTitle = async (to: RouteLocationNormalized) => {
   const alias = to.params?.alias as string | undefined
   if (!alias) {
-    next()
     return
   }
 
   try {
     const exposureInfo = await useExposureStore().getExposureInfo(alias)
-    const title = exposureInfo?.exposure?.description
-    if (title) {
-      to.meta.title = title
-    }
-    next()
+    return exposureInfo?.exposure?.description
   } catch (error) {
     console.error(`Error fetching exposure info for alias ${alias}:`, error)
-    next()
   }
 }
 
-const workspaceBeforeEnter: NavigationGuard = async (to, _from, next) => {
+const resolveWorkspaceTitle = async (to: RouteLocationNormalized) => {
   const alias = to.params?.alias as string | undefined
   if (!alias) {
-    next()
     return
   }
 
@@ -74,15 +67,24 @@ const workspaceBeforeEnter: NavigationGuard = async (to, _from, next) => {
     const commitId = to.params?.commitId as string | ''
     const path = to.params?.path as string | ''
     const workspaceInfo = await useWorkspaceStore().getWorkspaceInfo(alias, commitId, path)
-    const title = workspaceInfo?.workspace?.description
-    if (title) {
-      to.meta.title = title
-    }
-    next()
+    return workspaceInfo?.workspace?.description
   } catch (error) {
     console.error(`Error fetching workspace info for alias ${alias}:`, error)
-    next()
   }
+}
+
+const resolveRouteTitle = async (to: RouteLocationNormalized) => {
+  const currentTitle = to.meta.title as string | undefined
+
+  if (to.name?.toString().startsWith('exposure')) {
+    return (await resolveExposureTitle(to)) || currentTitle
+  }
+
+  if (to.name?.toString().startsWith('workspace')) {
+    return (await resolveWorkspaceTitle(to)) || currentTitle
+  }
+
+  return currentTitle
 }
 
 const router = createRouter({
@@ -120,7 +122,6 @@ const router = createRouter({
         workspaceDetailRouteSuffixes,
       ),
       meta: { title: `Workspace Detail – ${title}` },
-      beforeEnter: workspaceBeforeEnter,
     },
     {
       path: '/workspaces/:alias/file/:commitId/:path(.+)',
@@ -132,7 +133,6 @@ const router = createRouter({
         workspaceFileRouteSuffixes,
       ),
       meta: { title: `Workspace File – ${title}` },
-      beforeEnter: workspaceBeforeEnter,
     },
     {
       path: '/exposures',
@@ -147,7 +147,6 @@ const router = createRouter({
       component: ExposureDetailView,
       alias: createAliases(exposureAliasBases, '/:alias', '/:alias/view'),
       meta: { title: `Exposure Detail – ${title}` },
-      beforeEnter: exposureBeforeEnter,
     },
     {
       path: '/exposures/:alias/:file(.+)/:view([^./]+)',
@@ -160,7 +159,6 @@ const router = createRouter({
         exposureFileViewRouteSuffixes
       ),
       meta: { title: `Exposure File – ${title}` },
-      beforeEnter: exposureBeforeEnter,
     },
     {
       path: '/exposures/:alias/:file(.+)',
@@ -173,7 +171,6 @@ const router = createRouter({
         exposureFileRouteSuffixes
       ),
       meta: { title: `Exposure File – ${title}` },
-      beforeEnter: exposureBeforeEnter,
     },
     {
       path: '/search',
@@ -194,6 +191,13 @@ const router = createRouter({
       meta: { title: `Page Not Found – ${title}` },
     },
   ],
+})
+
+router.beforeResolve(async (to) => {
+  const resolvedTitle = await resolveRouteTitle(to)
+  if (resolvedTitle) {
+    to.meta.title = resolvedTitle
+  }
 })
 
 router.afterEach((to) => {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -8,6 +8,7 @@ import SearchView from '@/views/SearchView.vue'
 import WorkspaceDetailView from '@/views/WorkspaceDetailView.vue'
 import WorkspaceView from '@/views/WorkspaceView.vue'
 import { useExposureStore } from '@/stores/exposure'
+import { useWorkspaceStore } from '@/stores/workspace'
 
 const title = 'Physiome Model Repository'
 const workspaceAliasBases = ['/workspace']
@@ -62,6 +63,28 @@ const exposureBeforeEnter: NavigationGuard = async (to, _from, next) => {
   }
 }
 
+const workspaceBeforeEnter: NavigationGuard = async (to, _from, next) => {
+  const alias = to.params?.alias as string | undefined
+  if (!alias) {
+    next()
+    return
+  }
+
+  try {
+    const commitId = to.params?.commitId as string | ''
+    const path = to.params?.path as string | ''
+    const workspaceInfo = await useWorkspaceStore().getWorkspaceInfo(alias, commitId, path)
+    const title = workspaceInfo?.workspace?.description
+    if (title) {
+      to.meta.title = title
+    }
+    next()
+  } catch (error) {
+    console.error(`Error fetching workspace info for alias ${alias}:`, error)
+    next()
+  }
+}
+
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
   scrollBehavior(to, from, savedPosition) {
@@ -97,6 +120,7 @@ const router = createRouter({
         workspaceDetailRouteSuffixes,
       ),
       meta: { title: `Workspace Detail – ${title}` },
+      beforeEnter: workspaceBeforeEnter,
     },
     {
       path: '/workspaces/:alias/file/:commitId/:path(.+)',
@@ -108,6 +132,7 @@ const router = createRouter({
         workspaceFileRouteSuffixes,
       ),
       meta: { title: `Workspace File – ${title}` },
+      beforeEnter: workspaceBeforeEnter,
     },
     {
       path: '/exposures',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,8 +9,10 @@ import NotFoundView from '@/views/NotFoundView.vue'
 import SearchView from '@/views/SearchView.vue'
 import WorkspaceDetailView from '@/views/WorkspaceDetailView.vue'
 import WorkspaceView from '@/views/WorkspaceView.vue'
+import { generateExposureTitle } from '@/utils/exposure'
+import { generateWorkspaceTitle } from '@/utils/workspace'
+import { TITLE } from '@/constants/global'
 
-const title = 'Physiome Model Repository'
 const workspaceAliasBases = ['/workspace']
 const workspaceDetailRouteSuffixes = ['/:alias', '/:alias/file', '/:alias/@@file']
 const workspaceFileRouteSuffixes = [
@@ -51,7 +53,8 @@ const resolveExposureTitle = async (to: RouteLocationNormalized) => {
 
   try {
     const exposureInfo = await useExposureStore().getExposureInfo(alias)
-    return exposureInfo?.exposure?.description || alias
+
+    return generateExposureTitle(exposureInfo?.exposure?.description, exposureInfo?.exposure?.id)
   } catch (error) {
     console.error(`Error fetching exposure info for alias ${alias}:`, error)
   }
@@ -69,7 +72,8 @@ const resolveWorkspaceTitle = async (to: RouteLocationNormalized) => {
     const commitId = typeof commitIdParam === 'string' ? commitIdParam : ''
     const path = typeof pathParam === 'string' ? pathParam : ''
     const workspaceInfo = await useWorkspaceStore().getWorkspaceInfo(alias, commitId, path)
-    return workspaceInfo?.workspace?.description || alias
+
+    return generateWorkspaceTitle(workspaceInfo?.workspace?.description, workspaceInfo?.workspace?.id)
   } catch (error) {
     console.error(`Error fetching workspace info for alias ${alias}:`, error)
   }
@@ -106,13 +110,13 @@ const router = createRouter({
       path: '/',
       name: 'home',
       component: HomeView,
-      meta: { title: title },
+      meta: { title: TITLE },
     },
     {
       path: '/workspaces',
       name: 'workspaces',
       component: WorkspaceView,
-      meta: { title: `Workspaces – ${title}` },
+      meta: { title: `Workspaces – ${TITLE}` },
     },
     {
       path: '/workspaces/:alias',
@@ -123,7 +127,7 @@ const router = createRouter({
         workspaceAliasBases,
         workspaceDetailRouteSuffixes,
       ),
-      meta: { title: `Workspace Detail – ${title}` },
+      meta: { title: `Workspace Detail – ${TITLE}` },
     },
     {
       path: '/workspaces/:alias/file/:commitId/:path(.+)',
@@ -134,21 +138,21 @@ const router = createRouter({
         workspaceAliasBases,
         workspaceFileRouteSuffixes,
       ),
-      meta: { title: `Workspace File – ${title}` },
+      meta: { title: `Workspace File – ${TITLE}` },
     },
     {
       path: '/exposures',
       name: 'exposures',
       component: ExposureView,
       alias: createAliases(exposureAliasBases, ''),
-      meta: { title: `Exposures – ${title}` },
+      meta: { title: `Exposures – ${TITLE}` },
     },
     {
       path: '/exposures/:alias',
       name: 'exposure-detail',
       component: ExposureDetailView,
       alias: createAliases(exposureAliasBases, '/:alias', '/:alias/view'),
-      meta: { title: `Exposure Detail – ${title}` },
+      meta: { title: `Exposure Detail – ${TITLE}` },
     },
     {
       path: '/exposures/:alias/:file(.+)/:view([^./]+)',
@@ -160,7 +164,7 @@ const router = createRouter({
         exposureAliasBases,
         exposureFileViewRouteSuffixes
       ),
-      meta: { title: `Exposure File – ${title}` },
+      meta: { title: `Exposure File – ${TITLE}` },
     },
     {
       path: '/exposures/:alias/:file(.+)',
@@ -172,25 +176,25 @@ const router = createRouter({
         exposureAliasBases,
         exposureFileRouteSuffixes
       ),
-      meta: { title: `Exposure File – ${title}` },
+      meta: { title: `Exposure File – ${TITLE}` },
     },
     {
       path: '/search',
       name: 'search-results',
       component: SearchView,
-      meta: { title: `Search Results – ${title}` },
+      meta: { title: `Search Results – ${TITLE}` },
     },
     {
       path: '/login',
       name: 'login',
       component: LoginView,
-      meta: { title: `Login – ${title}` },
+      meta: { title: `Login – ${TITLE}` },
     },
     {
       path: '/:pathMatch(.*)*',
       name: 'not-found',
       component: NotFoundView,
-      meta: { title: `Page Not Found – ${title}` },
+      meta: { title: `Page Not Found – ${TITLE}` },
     },
   ],
 })
@@ -198,7 +202,7 @@ const router = createRouter({
 router.beforeResolve(async (to) => {
   const resolvedTitle = await resolveRouteTitle(to)
   if (resolvedTitle) {
-    to.meta.title = resolvedTitle.includes(title) ? resolvedTitle : `${resolvedTitle} – ${title}`
+    to.meta.title = resolvedTitle.includes(TITLE) ? resolvedTitle : `${resolvedTitle} – ${TITLE}`
   }
 })
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -80,6 +80,8 @@ const resolveWorkspaceTitle = async (to: RouteLocationNormalized) => {
     return generateWorkspaceTitle(
       workspaceInfo?.workspace?.description,
       workspaceInfo?.workspace?.id,
+      commitId,
+      path,
       true,
     )
   } catch (error) {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -51,7 +51,7 @@ const resolveExposureTitle = async (to: RouteLocationNormalized) => {
 
   try {
     const exposureInfo = await useExposureStore().getExposureInfo(alias)
-    return exposureInfo?.exposure?.description
+    return exposureInfo?.exposure?.description || alias
   } catch (error) {
     console.error(`Error fetching exposure info for alias ${alias}:`, error)
   }
@@ -69,7 +69,7 @@ const resolveWorkspaceTitle = async (to: RouteLocationNormalized) => {
     const commitId = typeof commitIdParam === 'string' ? commitIdParam : ''
     const path = typeof pathParam === 'string' ? pathParam : ''
     const workspaceInfo = await useWorkspaceStore().getWorkspaceInfo(alias, commitId, path)
-    return workspaceInfo?.workspace?.description
+    return workspaceInfo?.workspace?.description || alias
   } catch (error) {
     console.error(`Error fetching workspace info for alias ${alias}:`, error)
   }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -73,7 +73,10 @@ const resolveWorkspaceTitle = async (to: RouteLocationNormalized) => {
     const path = typeof pathParam === 'string' ? pathParam : ''
     const workspaceInfo = await useWorkspaceStore().getWorkspaceInfo(alias, commitId, path)
 
-    return generateWorkspaceTitle(workspaceInfo?.workspace?.description, workspaceInfo?.workspace?.id)
+    return generateWorkspaceTitle(
+      workspaceInfo?.workspace?.description,
+      workspaceInfo?.workspace?.id,
+    )
   } catch (error) {
     console.error(`Error fetching workspace info for alias ${alias}:`, error)
   }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -212,7 +212,10 @@ const router = createRouter({
 router.beforeResolve(async (to) => {
   const resolvedTitle = await resolveRouteTitle(to)
   if (resolvedTitle) {
-    to.meta.title = resolvedTitle.includes(TITLE) ? resolvedTitle : `${resolvedTitle} – ${TITLE}`
+    to.meta.title =
+       resolvedTitle === TITLE || resolvedTitle.endsWith(` – ${TITLE}`)
+         ? resolvedTitle
+         : `${resolvedTitle} – ${TITLE}`
   }
 })
 

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -7,6 +7,7 @@ import NotFoundView from '@/views/NotFoundView.vue'
 import SearchView from '@/views/SearchView.vue'
 import WorkspaceDetailView from '@/views/WorkspaceDetailView.vue'
 import WorkspaceView from '@/views/WorkspaceView.vue'
+import { useExposureStore } from '@/stores/exposure'
 
 const title = 'Physiome Model Repository'
 const workspaceAliasBases = ['/workspace']
@@ -40,6 +41,26 @@ const createPluralRouteAliases = (pluralBase: string, aliasBases: string[], suff
   ...suffixes.slice(1).map((suffix) => `${pluralBase}${suffix}`),
   ...createAliases(aliasBases, ...suffixes),
 ]
+
+const exposureBeforeEnter = async (to: any, from: any, next: any) => {
+  const alias = to.params?.alias as string | undefined
+  if (!alias) {
+    next()
+    return
+  }
+
+  try {
+    const exposureInfo = await useExposureStore().getExposureInfo(alias)
+    const title = exposureInfo?.exposure?.description
+    if (title) {
+      to.meta.title = title
+    }
+    next()
+  } catch (error) {
+    console.error(`Error fetching exposure info for alias ${alias}:`, error)
+    next()
+  }
+}
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -101,6 +122,7 @@ const router = createRouter({
       component: ExposureDetailView,
       alias: createAliases(exposureAliasBases, '/:alias', '/:alias/view'),
       meta: { title: `Exposure Detail – ${title}` },
+      beforeEnter: exposureBeforeEnter,
     },
     {
       path: '/exposures/:alias/:file(.+)/:view([^./]+)',
@@ -113,6 +135,7 @@ const router = createRouter({
         exposureFileViewRouteSuffixes
       ),
       meta: { title: `Exposure File – ${title}` },
+      beforeEnter: exposureBeforeEnter,
     },
     {
       path: '/exposures/:alias/:file(.+)',
@@ -125,6 +148,7 @@ const router = createRouter({
         exposureFileRouteSuffixes
       ),
       meta: { title: `Exposure File – ${title}` },
+      beforeEnter: exposureBeforeEnter,
     },
     {
       path: '/search',

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -64,8 +64,10 @@ const resolveWorkspaceTitle = async (to: RouteLocationNormalized) => {
   }
 
   try {
-    const commitId = to.params?.commitId as string | ''
-    const path = to.params?.path as string | ''
+    const commitIdParam = to.params?.commitId
+    const pathParam = to.params?.path
+    const commitId = typeof commitIdParam === 'string' ? commitIdParam : ''
+    const path = typeof pathParam === 'string' ? pathParam : ''
     const workspaceInfo = await useWorkspaceStore().getWorkspaceInfo(alias, commitId, path)
     return workspaceInfo?.workspace?.description
   } catch (error) {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,6 @@
 import { createRouter, createWebHistory, type NavigationGuard } from 'vue-router'
+import { useExposureStore } from '@/stores/exposure'
+import { useWorkspaceStore } from '@/stores/workspace'
 import ExposureDetailView from '@/views/ExposureDetailView.vue'
 import ExposureView from '@/views/ExposureView.vue'
 import HomeView from '@/views/HomeView.vue'
@@ -7,8 +9,6 @@ import NotFoundView from '@/views/NotFoundView.vue'
 import SearchView from '@/views/SearchView.vue'
 import WorkspaceDetailView from '@/views/WorkspaceDetailView.vue'
 import WorkspaceView from '@/views/WorkspaceView.vue'
-import { useExposureStore } from '@/stores/exposure'
-import { useWorkspaceStore } from '@/stores/workspace'
 
 const title = 'Physiome Model Repository'
 const workspaceAliasBases = ['/workspace']

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,4 +1,4 @@
-import { createRouter, createWebHistory } from 'vue-router'
+import { createRouter, createWebHistory, type NavigationGuard } from 'vue-router'
 import ExposureDetailView from '@/views/ExposureDetailView.vue'
 import ExposureView from '@/views/ExposureView.vue'
 import HomeView from '@/views/HomeView.vue'
@@ -42,7 +42,7 @@ const createPluralRouteAliases = (pluralBase: string, aliasBases: string[], suff
   ...createAliases(aliasBases, ...suffixes),
 ]
 
-const exposureBeforeEnter = async (to: any, from: any, next: any) => {
+const exposureBeforeEnter: NavigationGuard = async (to, _from, next) => {
   const alias = to.params?.alias as string | undefined
   if (!alias) {
     next()

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,6 +1,9 @@
 import { createRouter, createWebHistory, type RouteLocationNormalized } from 'vue-router'
+import { TITLE } from '@/constants/global'
 import { useExposureStore } from '@/stores/exposure'
 import { useWorkspaceStore } from '@/stores/workspace'
+import { generateExposureTitle } from '@/utils/exposure'
+import { generateWorkspaceTitle } from '@/utils/workspace'
 import ExposureDetailView from '@/views/ExposureDetailView.vue'
 import ExposureView from '@/views/ExposureView.vue'
 import HomeView from '@/views/HomeView.vue'
@@ -9,9 +12,6 @@ import NotFoundView from '@/views/NotFoundView.vue'
 import SearchView from '@/views/SearchView.vue'
 import WorkspaceDetailView from '@/views/WorkspaceDetailView.vue'
 import WorkspaceView from '@/views/WorkspaceView.vue'
-import { generateExposureTitle } from '@/utils/exposure'
-import { generateWorkspaceTitle } from '@/utils/workspace'
-import { TITLE } from '@/constants/global'
 
 const workspaceAliasBases = ['/workspace']
 const workspaceDetailRouteSuffixes = ['/:alias', '/:alias/file', '/:alias/@@file']

--- a/src/utils/citation.test.ts
+++ b/src/utils/citation.test.ts
@@ -182,7 +182,11 @@ describe('normaliseUrl', () => {
   })
 
   it('preserves URL with special characters %20 for spaces', () => {
-    expect(normaliseUrl('http://localhost:5173/pmrapp-frontend/exposures/d6a/mapclient%20workflow/Argon_Viewer-previous-docs/document_whole_body.json')).toBe(
+    expect(
+      normaliseUrl(
+        'http://localhost:5173/pmrapp-frontend/exposures/d6a/mapclient%20workflow/Argon_Viewer-previous-docs/document_whole_body.json',
+      ),
+    ).toBe(
       'http://localhost:5173/pmrapp-frontend/exposures/d6a/mapclient%20workflow/Argon_Viewer-previous-docs/document_whole_body.json',
     )
   })

--- a/src/utils/citation.test.ts
+++ b/src/utils/citation.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest'
 import {
+  ensureSentence,
   formatCitation,
-  parseFullNameToAuthor,
   formatCitationAuthor,
   formatIndividualAuthor,
-  ensureSentence,
   normaliseUrl,
+  parseFullNameToAuthor,
 } from './citation'
 
 describe('parseFullNameToAuthor', () => {

--- a/src/utils/exposure.test.ts
+++ b/src/utils/exposure.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { TITLE } from '@/constants/global'
+import { mockExposureInfo } from '@/mocks/exposureInfo'
+import {
+  generateExposureTitle,
+  getExposureIdFromResourcePath,
+} from './exposure'
+
+describe('getExposureIdFromResourcePath', () => {
+  it('extracts exposure ID from a valid resource path', () => {
+    const id = mockExposureInfo.exposure.id
+    expect(getExposureIdFromResourcePath(`/exposure/${id}/some-resource`)).toBe(id)
+  })
+
+  it('returns null when no exposure ID is present', () => {
+    expect(getExposureIdFromResourcePath('/workspace/682/file')).toBeNull()
+  })
+
+  it('returns null for an empty string', () => {
+    expect(getExposureIdFromResourcePath('')).toBeNull()
+  })
+
+  it('returns null for a path with non-numeric ID', () => {
+    expect(getExposureIdFromResourcePath('/exposure/abc/')).toBeNull()
+  })
+})
+
+describe('generateExposureTitle', () => {
+  const { description, id } = mockExposureInfo.exposure
+
+  it('returns generic title when both description and id are null', () => {
+    expect(generateExposureTitle(null, null)).toBe('Exposure Detail')
+  })
+
+  it('uses description from mock data', () => {
+    expect(generateExposureTitle(description, id)).toBe(description)
+  })
+
+  it('accepts description with surrounding whitespace', () => {
+    expect(generateExposureTitle('  My Exposure  ', id)).toBe('  My Exposure  ')
+  })
+
+  it('falls back to ID when description is null', () => {
+    expect(generateExposureTitle(null, id)).toBe(`Exposure ${id}`)
+  })
+
+  it('falls back to ID when description is empty', () => {
+    expect(generateExposureTitle('', id)).toBe(`Exposure ${id}`)
+  })
+
+  describe('with title suffix', () => {
+    it('appends site title suffix when withTitleSuffix is true', () => {
+      expect(generateExposureTitle(description, id, true)).toBe(
+        `${description} – ${TITLE}`,
+      )
+    })
+
+    it('appends suffix with generic title', () => {
+      expect(generateExposureTitle(null, null, true)).toBe(
+        `Exposure Detail – ${TITLE}`,
+      )
+    })
+
+    it('appends suffix with ID fallback', () => {
+      expect(generateExposureTitle(null, id, true)).toBe(`Exposure ${id} – ${TITLE}`)
+    })
+  })
+})

--- a/src/utils/exposure.ts
+++ b/src/utils/exposure.ts
@@ -26,7 +26,7 @@ export const getExposureIdFromResourcePath = (resourcePath: string): number | nu
 export const generateExposureTitle = (
   description: string | null | undefined,
   id: number | null | undefined,
-  withTitleSuffix = false
+  withTitleSuffix = false,
 ): string => {
   let title: string
 

--- a/src/utils/exposure.ts
+++ b/src/utils/exposure.ts
@@ -1,3 +1,5 @@
+import { TITLE } from '@/constants/global'
+
 /**
  * Utility function to extract the exposure ID from a resource path string.
  *
@@ -11,4 +13,26 @@ export const getExposureIdFromResourcePath = (resourcePath: string): number | nu
     return Number(match[1])
   }
   return null
+}
+
+/**
+ * Generate exposure page title from description or ID.
+ *
+ * @param description The description of the exposure, if available.
+ * @param id The ID of the exposure, used as a fallback if description is not available.
+ * @returns A string representing the title for the exposure page.
+ */
+export const generateExposureTitle = (description: string | null | undefined, id: number | null | undefined): string => {
+  // Generic title if neither description nor ID is available.
+  if (!description && !id) {
+    return `Exposure Detail – ${TITLE}`
+  }
+
+  // Title using description.
+  if (description && description.trim() !== '') {
+    return `${description} – ${TITLE}`
+  }
+
+  // Fallback title using ID.
+  return `Exposure ${id} – ${TITLE}`
 }

--- a/src/utils/exposure.ts
+++ b/src/utils/exposure.ts
@@ -20,13 +20,13 @@ export const getExposureIdFromResourcePath = (resourcePath: string): number | nu
  *
  * @param description The description of the exposure, if available.
  * @param id The ID of the exposure, used as a fallback if description is not available.
- * @param withTitleSuffix When true (default), appends the site title suffix.
+ * @param withTitleSuffix When true, appends the site title suffix. Defaults to false.
  * @returns A string representing the title for the exposure page.
  */
 export const generateExposureTitle = (
   description: string | null | undefined,
   id: number | null | undefined,
-  withTitleSuffix = true
+  withTitleSuffix = false
 ): string => {
   let title: string
 

--- a/src/utils/exposure.ts
+++ b/src/utils/exposure.ts
@@ -20,22 +20,26 @@ export const getExposureIdFromResourcePath = (resourcePath: string): number | nu
  *
  * @param description The description of the exposure, if available.
  * @param id The ID of the exposure, used as a fallback if description is not available.
+ * @param withTitleSuffix When true (default), appends the site title suffix.
  * @returns A string representing the title for the exposure page.
  */
 export const generateExposureTitle = (
   description: string | null | undefined,
   id: number | null | undefined,
+  withTitleSuffix = true
 ): string => {
+  let title: string
+
   // Generic title if neither description nor ID is available.
   if (!description && !id) {
-    return `Exposure Detail – ${TITLE}`
+    title = 'Exposure Detail'
+  } else if (description && description.trim() !== '') {
+    // Title using description.
+    title = description
+  } else {
+    // Fallback title using ID.
+    title = `Exposure ${id}`
   }
 
-  // Title using description.
-  if (description && description.trim() !== '') {
-    return `${description} – ${TITLE}`
-  }
-
-  // Fallback title using ID.
-  return `Exposure ${id} – ${TITLE}`
+  return withTitleSuffix ? `${title} – ${TITLE}` : title
 }

--- a/src/utils/exposure.ts
+++ b/src/utils/exposure.ts
@@ -22,7 +22,10 @@ export const getExposureIdFromResourcePath = (resourcePath: string): number | nu
  * @param id The ID of the exposure, used as a fallback if description is not available.
  * @returns A string representing the title for the exposure page.
  */
-export const generateExposureTitle = (description: string | null | undefined, id: number | null | undefined): string => {
+export const generateExposureTitle = (
+  description: string | null | undefined,
+  id: number | null | undefined,
+): string => {
   // Generic title if neither description nor ID is available.
   if (!description && !id) {
     return `Exposure Detail – ${TITLE}`

--- a/src/utils/workspace.test.ts
+++ b/src/utils/workspace.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest'
+import { TITLE } from '@/constants/global'
+import { mockWorkspaceInfo } from '@/mocks/workspaceInfo'
+import { generateWorkspaceTitle } from './workspace'
+
+describe('generateWorkspaceTitle', () => {
+  const { description, id } = mockWorkspaceInfo.workspace
+  const commitId = mockWorkspaceInfo.commit.commit_id
+
+  it('returns generic title when both description and id are null', () => {
+    expect(generateWorkspaceTitle(null, null)).toBe('Workspace Detail')
+  })
+
+  it('uses description from mock data', () => {
+    expect(generateWorkspaceTitle(description, id)).toBe(description)
+  })
+
+  it('accepts description with surrounding whitespace', () => {
+    expect(generateWorkspaceTitle('  My Workspace  ', id)).toBe('  My Workspace  ')
+  })
+
+  it('falls back to ID when description is null', () => {
+    expect(generateWorkspaceTitle(null, id)).toBe(`Workspace ${id}`)
+  })
+
+  it('falls back to ID when description is empty', () => {
+    expect(generateWorkspaceTitle('', id)).toBe(`Workspace ${id}`)
+  })
+
+  describe('with commitId and path', () => {
+    const filePath = 'baylor_hollingworth_chandler_2002_a.cellml'
+
+    it('appends commit hash and path when both are provided', () => {
+      expect(generateWorkspaceTitle(description, id, commitId, filePath)).toBe(
+        `${description} @ ${commitId.substring(0, 12)} / ${filePath}`,
+      )
+    })
+
+    it('does not append commit info when commitId is undefined', () => {
+      expect(generateWorkspaceTitle(description, id, undefined, filePath)).toBe(description)
+    })
+
+    it('does not append commit info when path is undefined', () => {
+      expect(generateWorkspaceTitle(description, id, commitId, undefined)).toBe(description)
+    })
+
+    it('replaces forward slashes with space-slash-space in path', () => {
+      const nestedPath = 'a/b/c/file.txt'
+      expect(generateWorkspaceTitle(description, id, commitId, nestedPath)).toBe(
+        `${description} @ ${commitId.substring(0, 12)} / a / b / c / file.txt`,
+      )
+    })
+
+    it('works with generic title when description and id are null', () => {
+      expect(generateWorkspaceTitle(null, null, commitId, 'path/to/file')).toBe(
+        `Workspace Detail @ ${commitId.substring(0, 12)} / path / to / file`,
+      )
+    })
+  })
+
+  describe('with title suffix', () => {
+    it('appends site title suffix when withTitleSuffix is true', () => {
+      expect(generateWorkspaceTitle(description, id, undefined, undefined, true)).toBe(
+        `${description} – ${TITLE}`,
+      )
+    })
+
+    it('appends suffix with generic title', () => {
+      expect(generateWorkspaceTitle(null, null, undefined, undefined, true)).toBe(
+        `Workspace Detail – ${TITLE}`,
+      )
+    })
+
+    it('appends suffix with ID fallback', () => {
+      expect(generateWorkspaceTitle(null, id, undefined, undefined, true)).toBe(
+        `Workspace ${id} – ${TITLE}`,
+      )
+    })
+
+    it('appends suffix along with commit and path info', () => {
+      expect(
+        generateWorkspaceTitle(description, id, commitId, 'file.txt', true),
+      ).toBe(`${description} @ ${commitId.substring(0, 12)} / file.txt – ${TITLE}`)
+    })
+  })
+})

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -11,6 +11,8 @@ import { TITLE } from '@/constants/global'
 export const generateWorkspaceTitle = (
   description: string | null | undefined,
   id: number | null | undefined,
+  commitId?: string,
+  path?: string,
   withTitleSuffix = false,
 ): string => {
   let title: string
@@ -24,6 +26,12 @@ export const generateWorkspaceTitle = (
   } else {
     // Fallback title using ID.
     title = `Workspace ${id}`
+  }
+
+  if (commitId && path) {
+    const truncatedCommitId = commitId.substring(0, 12)
+    const pathsWithSpace = path.split('/').join(' / ')
+    title = `${title} @ ${truncatedCommitId} / ${pathsWithSpace}`
   }
 
   return withTitleSuffix ? `${title} – ${TITLE}` : title

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -11,7 +11,7 @@ import { TITLE } from '@/constants/global'
 export const generateWorkspaceTitle = (
   description: string | null | undefined,
   id: number | null | undefined,
-  withTitleSuffix = false
+  withTitleSuffix = false,
 ): string => {
   let title: string
 

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -5,13 +5,13 @@ import { TITLE } from '@/constants/global'
  *
  * @param description The description of the workspace, if available.
  * @param id The ID of the workspace, used as a fallback if description is not available.
- * @param withTitleSuffix When true (default), appends the site title suffix.
+ * @param withTitleSuffix When true, appends the site title suffix. Defaults to false.
  * @returns A string representing the title for the workspace page.
  */
 export const generateWorkspaceTitle = (
   description: string | null | undefined,
   id: number | null | undefined,
-  withTitleSuffix = true
+  withTitleSuffix = false
 ): string => {
   let title: string
 

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -5,22 +5,26 @@ import { TITLE } from '@/constants/global'
  *
  * @param description The description of the workspace, if available.
  * @param id The ID of the workspace, used as a fallback if description is not available.
+ * @param withTitleSuffix When true (default), appends the site title suffix.
  * @returns A string representing the title for the workspace page.
  */
 export const generateWorkspaceTitle = (
   description: string | null | undefined,
   id: number | null | undefined,
+  withTitleSuffix = true
 ): string => {
+  let title: string
+
   // Generic title if neither description nor ID is available.
   if (!description && !id) {
-    return `Workspace Detail – ${TITLE}`
+    title = 'Workspace Detail'
+  } else if (description && description.trim() !== '') {
+    // Title using description.
+    title = description
+  } else {
+    // Fallback title using ID.
+    title = `Workspace ${id}`
   }
 
-  // Title using description.
-  if (description && description.trim() !== '') {
-    return `${description} – ${TITLE}`
-  }
-
-  // Fallback title using ID.
-  return `Workspace ${id} – ${TITLE}`
+  return withTitleSuffix ? `${title} – ${TITLE}` : title
 }

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -7,7 +7,10 @@ import { TITLE } from '@/constants/global'
  * @param id The ID of the workspace, used as a fallback if description is not available.
  * @returns A string representing the title for the workspace page.
  */
-export const generateWorkspaceTitle = (description: string | null | undefined, id: number | null | undefined): string => {
+export const generateWorkspaceTitle = (
+  description: string | null | undefined,
+  id: number | null | undefined,
+): string => {
   // Generic title if neither description nor ID is available.
   if (!description && !id) {
     return `Workspace Detail – ${TITLE}`

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -1,0 +1,23 @@
+import { TITLE } from '@/constants/global'
+
+/**
+ * Generate workspace page title from description or ID.
+ *
+ * @param description The description of the workspace, if available.
+ * @param id The ID of the workspace, used as a fallback if description is not available.
+ * @returns A string representing the title for the workspace page.
+ */
+export const generateWorkspaceTitle = (description: string | null | undefined, id: number | null | undefined): string => {
+  // Generic title if neither description nor ID is available.
+  if (!description && !id) {
+    return `Workspace Detail – ${TITLE}`
+  }
+
+  // Title using description.
+  if (description && description.trim() !== '') {
+    return `${description} – ${TITLE}`
+  }
+
+  // Fallback title using ID.
+  return `Workspace ${id} – ${TITLE}`
+}


### PR DESCRIPTION
Fixes #169.

### Additional changes

• Fixes for button hover states.
• Biome lint update ignores in config for Vue multi-word component names since `eslint` has been removed.
• Update page header component with different font sizes.
• Standardised website title usage using a global constant.
• Workspace file title updated to include title and commit ID (same as in PMR2).


### Examples

In the following screenshot, the title in the browser's tab is the same as the page title. 
https://akhuoa.github.io/pmrapp-frontend/exposures/b03

<img width="800" alt="image" src="https://github.com/user-attachments/assets/bb911155-c753-4248-a8f9-9762e142b615" />

<br><br><br>

The title of the file has workspace description and commit ID (truncated, similar to PMR2).

- https://akhuoa.github.io/pmrapp-frontend/workspaces/6b0/file/a8a92308e217ac5626809237dd90a31240b22834/README.md

