### PR TITLE
Fix search overlay height on shorter screens

### DIFF
--- a/src/components/molecules/Dialog.test.ts
+++ b/src/components/molecules/Dialog.test.ts
@@ -1,0 +1,73 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import Dialog from '@/components/molecules/Dialog.vue'
+
+describe('Dialog', () => {
+  it('does not render when show is false', () => {
+    const wrapper = mount(Dialog, { props: { show: false } })
+    expect(wrapper.find('.fixed').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('renders title and slot content when shown', () => {
+    const wrapper = mount(Dialog, {
+      props: { show: true, title: 'Dialog Title' },
+      slots: {
+        default: '<p data-test="dialog-content">Dialog body content</p>',
+      },
+    })
+    expect(wrapper.find('.fixed').exists()).toBe(true)
+    expect(wrapper.find('h2').text()).toBe('Dialog Title')
+    expect(wrapper.find('[data-test="dialog-content"]').text()).toBe('Dialog body content')
+    wrapper.unmount()
+  })
+
+  it('hides title element when title is not provided', () => {
+    const wrapper = mount(Dialog, {
+      props: { show: true },
+      slots: {
+        default: '<div>Content</div>',
+      },
+    })
+    expect(wrapper.find('h2').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('emits close when close button is clicked', async () => {
+    const wrapper = mount(Dialog, {
+      props: { show: true },
+      slots: {
+        default: '<div>Content</div>',
+      },
+    })
+    await wrapper.find('button[aria-label="Close"]').trigger('click')
+    expect(wrapper.emitted('close')).toBeTruthy()
+    wrapper.unmount()
+  })
+
+  it('emits close when backdrop is clicked', async () => {
+    const wrapper = mount(Dialog, {
+      props: { show: true },
+      slots: {
+        default: '<div>Content</div>',
+      },
+    })
+    const backdrop = wrapper.find('.fixed')
+    await backdrop.trigger('mousedown', { button: 0 })
+    await backdrop.trigger('mouseup')
+    expect(wrapper.emitted('close')).toBeTruthy()
+    wrapper.unmount()
+  })
+
+  it('emits close when Escape key is pressed', async () => {
+    const wrapper = mount(Dialog, {
+      props: { show: true },
+      slots: {
+        default: '<div>Content</div>',
+      },
+    })
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }))
+    expect(wrapper.emitted('close')).toBeTruthy()
+    wrapper.unmount()
+  })
+})

--- a/src/components/molecules/Dialog.vue
+++ b/src/components/molecules/Dialog.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
+import CloseButton from '@/components/atoms/CloseButton.vue'
+
+const props = defineProps<{
+  show: boolean
+  title?: string
+  position?: 'center' | 'top'
+}>()
+
+const emit = defineEmits<(e: 'close') => void>()
+
+const dialogRef = ref<HTMLElement | null>(null)
+
+let isMouseDownOnBackdrop = false
+
+const positionClasses = computed(() => {
+  return props.position === 'top' ? 'items-start pt-8' : 'items-center'
+})
+
+const headerClasses = computed(() => {
+  return props.title
+    ? 'justify-between items-center border-b border-gray-200 dark:border-gray-700'
+    : 'justify-end'
+})
+
+const handleBackdropMouseDown = (event: MouseEvent) => {
+  if (event.button !== 0) return
+  isMouseDownOnBackdrop = true
+}
+
+const handleBackdropMouseUp = (event: MouseEvent) => {
+  if (isMouseDownOnBackdrop && event.target === event.currentTarget) {
+    emit('close')
+  }
+  isMouseDownOnBackdrop = false
+}
+
+const handleKeyDown = (event: KeyboardEvent) => {
+  if (event.key === 'Escape') {
+    emit('close')
+  }
+}
+
+watch(
+  () => props.show,
+  (newVal) => {
+    if (newVal) {
+      nextTick(() => {
+        dialogRef.value?.focus()
+      })
+      document.addEventListener('keydown', handleKeyDown)
+    } else {
+      document.removeEventListener('keydown', handleKeyDown)
+      isMouseDownOnBackdrop = false
+    }
+  },
+  { immediate: true },
+)
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleKeyDown)
+})
+</script>
+
+<template>
+  <div
+    v-if="show"
+    class="fixed inset-0 bg-gray-800/75 dark:bg-gray-900/75 backdrop-blur-sm z-250 flex justify-center"
+    :class="positionClasses"
+    @mousedown.self="handleBackdropMouseDown"
+    @mouseup="handleBackdropMouseUp"
+  >
+    <div
+      ref="dialogRef"
+      tabindex="-1"
+      role="dialog"
+      aria-modal="true"
+      :aria-label="title || 'Dialog'"
+      class="relative flex max-h-[calc(100vh-4rem)] w-full max-w-4xl flex-col overflow-hidden rounded-lg bg-white shadow-lg dark:bg-gray-800"
+    >
+      <div class="flex p-4" :class="headerClasses">
+        <h2 v-if="title" class="text-lg font-semibold">{{ title }}</h2>
+        <CloseButton @click="emit('close')" />
+      </div>
+      <div class="min-h-0 flex-1 p-4 overflow-y-auto">
+        <slot />
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/components/organisms/Header.vue
+++ b/src/components/organisms/Header.vue
@@ -64,8 +64,8 @@ const isActive = (path: string) => computed(() => route.path.startsWith(path))
         </ul>
       </nav>
     </div>
-    <SearchOverlay :show="isSearchOverlayVisible" @close="isSearchOverlayVisible = false" />
   </header>
+  <SearchOverlay :show="isSearchOverlayVisible" @close="isSearchOverlayVisible = false" />
 </template>
 
 <style scoped>

--- a/src/components/organisms/SearchOverlay.vue
+++ b/src/components/organisms/SearchOverlay.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, onUnmounted, ref, watch } from 'vue'
+import { nextTick, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import SearchInput from '@/components/molecules/SearchInput.vue'
 import { SEARCH_KIND_NAMES } from '@/constants/search'
@@ -17,12 +17,6 @@ const router = useRouter()
 const route = useRoute()
 const searchInputRef = ref<InstanceType<typeof SearchInput> | null>(null)
 
-const handleKeyDown = (event: KeyboardEvent) => {
-  if (event.key === 'Escape') {
-    emit('close')
-  }
-}
-
 watch(
   () => props.show,
   (newVal) => {
@@ -35,9 +29,6 @@ watch(
           searchInputRef.value?.searchInputRef?.focus()
         })
       })
-      document.addEventListener('keydown', handleKeyDown)
-    } else {
-      document.removeEventListener('keydown', handleKeyDown)
     }
   },
 )
@@ -50,10 +41,6 @@ watch(
     }
   },
 )
-
-onUnmounted(() => {
-  document.removeEventListener('keydown', handleKeyDown)
-})
 
 const handleSearch = (searchKind: string, searchTerm: string) => {
   router.push({ path: '/search', query: buildSearchQuery(searchKind, searchTerm, route.query) })

--- a/src/components/organisms/SearchOverlay.vue
+++ b/src/components/organisms/SearchOverlay.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { nextTick, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
-import CloseButton from '@/components/atoms/CloseButton.vue'
 import SearchInput from '@/components/molecules/SearchInput.vue'
 import { SEARCH_KIND_NAMES } from '@/constants/search'
 import { buildQuerySearchQuery, buildSearchQuery, parseQueryFiltersFromQuery } from '@/utils/search'
-import Keycap from '../atoms/Keycap.vue'
+import Keycap from '@/components/atoms/Keycap.vue'
+import Dialog from '@/components/molecules/Dialog.vue'
 
 const props = defineProps<{
   show: boolean
@@ -16,20 +16,6 @@ const emit = defineEmits<(e: 'close') => void>()
 const router = useRouter()
 const route = useRoute()
 const searchInputRef = ref<InstanceType<typeof SearchInput> | null>(null)
-
-let isMouseDownOnBackdrop = false
-
-const handleBackdropMouseDown = (event: MouseEvent) => {
-  if (event.button !== 0) return
-  isMouseDownOnBackdrop = true
-}
-
-const handleBackdropMouseUp = (event: MouseEvent) => {
-  if (isMouseDownOnBackdrop && event.target === event.currentTarget) {
-    emit('close')
-  }
-  isMouseDownOnBackdrop = false
-}
 
 const handleKeyDown = (event: KeyboardEvent) => {
   if (event.key === 'Escape') {
@@ -42,12 +28,12 @@ watch(
   (newVal) => {
     if (newVal) {
       nextTick(() => {
+        // TODO: Fix the focus issue.
         searchInputRef.value?.searchInputRef?.focus()
       })
       document.addEventListener('keydown', handleKeyDown)
     } else {
       document.removeEventListener('keydown', handleKeyDown)
-      isMouseDownOnBackdrop = false
     }
   },
 )
@@ -93,33 +79,27 @@ const getInitialTerm = (): string => {
 </script>
 
 <template>
-  <div
-    v-if="show"
-    class="fixed inset-0 bg-gray-800/75 dark:bg-gray-900/75 backdrop-blur-sm z-50 flex justify-center items-start pt-20"
-    @mousedown.self="handleBackdropMouseDown"
-    @mouseup="handleBackdropMouseUp"
+  <Dialog
+    :show="show"
+    title="Search"
+    position="top"
+    @close="emit('close')"
   >
-    <div class="w-full max-w-4xl bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4">
-      <div class="flex justify-between items-center mb-4 border-b border-gray-200 dark:border-gray-700 pb-2">
-        <h2 class="text-lg font-semibold">Search</h2>
-        <CloseButton @click="emit('close')" />
-      </div>
-      <div class="my-4 text-sm text-gray-500 dark:text-gray-400">
-        Type a term and press <Keycap>Enter</Keycap> to search the repository,
-        or use the more options to filter by category (author, keyword, publication references), or combine both.
-      </div>
-      <div class="pb-4">
-        <SearchInput
-          ref="searchInputRef"
-          :inOverlay="true"
-          :initial-kind="''"
-          :initial-term="getInitialTerm()"
-          :initial-filters="parseQueryFiltersFromQuery(route.query, SEARCH_KIND_NAMES)"
-          @search="handleSearch"
-          @querySearch="handleQuerySearch"
-          @close="emit('close')"
-        />
-      </div>
+    <div class="mb-4 text-sm text-gray-500 dark:text-gray-400">
+      Type a term and press <Keycap>Enter</Keycap> to search the repository,
+      or use the more options to filter by category (author, keyword, publication references), or combine both.
     </div>
-  </div>
+    <div class="pb-4">
+      <SearchInput
+        ref="searchInputRef"
+        :inOverlay="true"
+        :initial-kind="''"
+        :initial-term="getInitialTerm()"
+        :initial-filters="parseQueryFiltersFromQuery(route.query, SEARCH_KIND_NAMES)"
+        @search="handleSearch"
+        @querySearch="handleQuerySearch"
+        @close="emit('close')"
+      />
+    </div>
+  </Dialog>
 </template>

--- a/src/components/organisms/SearchOverlay.vue
+++ b/src/components/organisms/SearchOverlay.vue
@@ -27,9 +27,13 @@ watch(
   () => props.show,
   (newVal) => {
     if (newVal) {
+      // Double nextTick to ensure focus happens
+      // after Dialog's own nextTick callback
+      // that focuses dialogRef (which steals focus).
       nextTick(() => {
-        // TODO: Fix the focus issue.
-        searchInputRef.value?.searchInputRef?.focus()
+        nextTick(() => {
+          searchInputRef.value?.searchInputRef?.focus()
+        })
       })
       document.addEventListener('keydown', handleKeyDown)
     } else {

--- a/src/components/organisms/SearchOverlay.vue
+++ b/src/components/organisms/SearchOverlay.vue
@@ -80,17 +80,15 @@ const getInitialTerm = (): string => {
       Type a term and press <Keycap>Enter</Keycap> to search the repository,
       or use the more options to filter by category (author, keyword, publication references), or combine both.
     </div>
-    <div class="pb-4">
-      <SearchInput
-        ref="searchInputRef"
-        :inOverlay="true"
-        :initial-kind="''"
-        :initial-term="getInitialTerm()"
-        :initial-filters="parseQueryFiltersFromQuery(route.query, SEARCH_KIND_NAMES)"
-        @search="handleSearch"
-        @querySearch="handleQuerySearch"
-        @close="emit('close')"
-      />
-    </div>
+    <SearchInput
+      ref="searchInputRef"
+      :inOverlay="true"
+      :initial-kind="''"
+      :initial-term="getInitialTerm()"
+      :initial-filters="parseQueryFiltersFromQuery(route.query, SEARCH_KIND_NAMES)"
+      @search="handleSearch"
+      @querySearch="handleQuerySearch"
+      @close="emit('close')"
+    />
   </Dialog>
 </template>


### PR DESCRIPTION
Fixes #202.

Fix search overlay height by using dialog component.
There is no functionality update for search function. 
There is a visual change for the search dialog position, which is now a little bit closer to the top bar. 

It can be tested at https://akhuoa.github.io/pmrapp-frontend/ and compared with https://physiome.github.io/pmrapp-frontend/ for visual changes.

### Testing

- Open the link (homepage) in a shorter window.
- Click on the search icon in the navigation.
- User should see the search dialog with the cursor focus on the input.
- Click on the "More..." button.
- User should see the scrollbar and should be able to see all category terms.

### Comparison

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td><img width="1328" height="830" alt="Screenshot 2026-06-26 at 12 21 16 PM" src="https://github.com/user-attachments/assets/a4d94663-193e-4a89-a4ab-65624126258f" /></td>
<td><img width="1328" height="830" alt="Screenshot 2026-06-26 at 12 20 43 PM" src="https://github.com/user-attachments/assets/5ca88528-55a1-402c-af00-b9acb83290a9" /></td></tr>
</table>




